### PR TITLE
add TraceContext spec style header encoding/decoding

### DIFF
--- a/src/oc_trace_context_binary.erl
+++ b/src/oc_trace_context_binary.erl
@@ -12,7 +12,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc Functions to support the binary format trace context serialization
+%% @doc Functions to support the binary format trace context serialization.
+%% Implements the spec found here
+%% [https://github.com/census-instrumentation/opencensus-specs/blob/7b426409/encodings/BinaryEncoding.md]
 %% @end
 %%%-------------------------------------------------------------------------
 -module(oc_trace_context_binary).

--- a/src/oc_trace_context_binary.erl
+++ b/src/oc_trace_context_binary.erl
@@ -28,24 +28,34 @@
 -define(SPAN_ID_FIELD_NUM, 1).
 -define(TRACE_OPTIONS_FIELD_NUM, 2).
 
--spec encode(opencensus:trace_context()) -> binary().
+-spec encode(opencensus:trace_context()) -> {ok, binary()} | {error, invalid}.
+encode(#trace_context{trace_id=TraceId,
+                      span_id=SpanId}) when TraceId =:= 0
+                                          ; SpanId =:= 0 ->
+    {error, invalid};
 encode(#trace_context{trace_id=TraceId,
                       span_id=SpanId,
                       enabled=Enabled}) ->
     Options = case Enabled of true -> <<1:8>>; _ -> <<0:8>> end,
-    <<?VERSION:8, 0:8, TraceId:128, 1:8, SpanId:64, 2:8, Options/binary>>.
+    {ok, <<?VERSION:8, 0:8, TraceId:128, 1:8, SpanId:64, 2:8, Options/binary>>}.
 
--spec decode(binary()) -> opencensus:trace_context().
+-spec decode(binary()) -> {ok, opencensus:trace_context()} | {error, invalid}.
 decode(<<0:8/integer, VersionFormat/binary>>) ->
     decode_0(VersionFormat, #trace_context{}).
 
 decode_0(<<>>, TraceContext) ->
-    TraceContext;
+    {ok, TraceContext};
+decode_0(<<?TRACE_ID_FIELD_NUM:8/signed-integer, TraceId:128/integer, _/binary>>, _)
+  when TraceId =:= 0 ->
+    {error, invalid};
 decode_0(<<?TRACE_ID_FIELD_NUM:8/signed-integer, TraceId:128/integer, Rest/binary>>, TraceContext) ->
     decode_0(Rest, TraceContext#trace_context{trace_id=TraceId});
+decode_0(<<?SPAN_ID_FIELD_NUM:8/signed-integer, SpanId:64/integer, _/binary>>, _)
+  when SpanId =:= 0 ->
+    {error, invalid};
 decode_0(<<?SPAN_ID_FIELD_NUM:8/signed-integer, SpanId:64/integer, Rest/binary>>, TraceContext) ->
     decode_0(Rest, TraceContext#trace_context{span_id=SpanId});
 decode_0(<<?TRACE_OPTIONS_FIELD_NUM:8/signed-integer, _TraceOptions:7, Enabled:1, Rest/binary>>, TraceContext) ->
     decode_0(Rest, TraceContext#trace_context{enabled=case Enabled of 1 -> true; _ -> false end});
 decode_0(_, TraceContext) ->
-    TraceContext.
+    {ok, TraceContext}.

--- a/src/oc_trace_context_headers.erl
+++ b/src/oc_trace_context_headers.erl
@@ -13,6 +13,8 @@
 %% limitations under the License.
 %%
 %% @doc Functions to support the http header format of the tracecontext-spec
+%% Implements the spec found here
+%% [https://github.com/TraceContext/tracecontext-spec/blob/018cd514b/HTTP_HEADER_FORMAT.md]
 %% @end
 %%%-------------------------------------------------------------------------
 -module(oc_trace_context_headers).

--- a/src/oc_trace_context_headers.erl
+++ b/src/oc_trace_context_headers.erl
@@ -1,0 +1,42 @@
+%%%-------------------------------------------------------------------------
+%% Copyright 2017, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Functions to support the http header format of the tracecontext-spec
+%% @end
+%%%-------------------------------------------------------------------------
+-module(oc_trace_context_headers).
+
+-export([encode/1,
+         decode/1]).
+
+-include("opencensus.hrl").
+
+-define(VERSION, "00").
+
+-spec encode(opencensus:trace_context()) -> iolist().
+encode(#trace_context{trace_id=TraceId,
+                      span_id=SpanId,
+                      enabled=Enabled}) ->
+    Options = case Enabled of true -> <<"01">>; _ -> <<"00">> end,
+    EncodedTraceId = io_lib:format("~32.16.0b", [TraceId]),
+    EncodedSpanId = io_lib:format("~16.16.0b", [SpanId]),
+    [?VERSION, "-", EncodedTraceId, "-", EncodedSpanId, "-", Options].
+
+-spec decode(binary()) -> opencensus:trace_context().
+decode(TraceContext) when is_list(TraceContext) ->
+    decode(list_to_binary(TraceContext));
+decode(<<?VERSION, "-", TraceId:32/binary, "-", SpanId:16/binary, "-", Enabled:2/binary, _Rest/binary>>) ->
+    #trace_context{trace_id=binary_to_integer(TraceId, 16),
+                   span_id=binary_to_integer(SpanId, 16),
+                   enabled=case Enabled of <<"01">> -> true; _ -> false end}.

--- a/test/oc_trace_context_SUITE.erl
+++ b/test/oc_trace_context_SUITE.erl
@@ -2,7 +2,7 @@
 %%% @doc
 %%% @end
 %%% ---------------------------------------------------------------------------
--module(oc_trace_context_binary_SUITE).
+-module(oc_trace_context_SUITE).
 
 -compile(export_all).
 
@@ -10,7 +10,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 all() ->
-    [encode_decode, decode_with_extra_junk].
+    [encode_decode, decode_with_extra_junk, encode_decode_headers].
 
 init_per_suite(Config) ->
     Config.
@@ -44,3 +44,13 @@ decode_with_extra_junk(_Config) ->
     Encoded = oc_trace_context_binary:encode(Decoded),
 
     ?assertMatch(Binary, Encoded).
+
+encode_decode_headers(_Config) ->
+    %% TraceId: 4bf92f3577b34da6a3ce929d0e0e4736
+    %% SpanId: 00f067aa0ba902b7
+    %% Enabled: true
+    Header = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01">>,
+    Decoded = oc_trace_context_headers:decode(Header),
+    Encoded = oc_trace_context_headers:encode(Decoded),
+    ?assertEqual(Header, list_to_binary(Encoded)),
+    ?assertEqual(Decoded, oc_trace_context_headers:decode(Encoded)).

--- a/test/oc_trace_context_SUITE.erl
+++ b/test/oc_trace_context_SUITE.erl
@@ -9,6 +9,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+-include("opencensus.hrl").
+
 all() ->
     [encode_decode, decode_with_extra_junk, encode_decode_headers].
 
@@ -29,10 +31,19 @@ encode_decode(_Config) ->
     %% SpanId: 7017280452245743464
     %% Enabled: true
     Binary = <<0,0,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,1,97,98,99,100,101,102,103,104,2,1>>,
-    Decoded = oc_trace_context_binary:decode(Binary),
-    Encoded = oc_trace_context_binary:encode(Decoded),
+    {ok, Decoded} = oc_trace_context_binary:decode(Binary),
+    {ok, Encoded} = oc_trace_context_binary:encode(Decoded),
+    ?assertMatch(Binary, Encoded),
 
-    ?assertMatch(Binary, Encoded).
+    InvalidBothIdsBinary = <<0:8,0:8,0:128,1:8,0:64,2:8,1>>,
+    ?assertEqual({error, invalid}, oc_trace_context_binary:decode(InvalidBothIdsBinary)),
+
+    InvalidTraceIdBinary = <<0:8,0:8,0:128,1:8,1:64,2:8,1>>,
+    ?assertEqual({error, invalid}, oc_trace_context_binary:decode(InvalidTraceIdBinary)),
+
+    InvalidSpanIdBinary = <<0:8,0:8,1:128,1:8,0:64,2:8,1>>,
+    ?assertEqual({error, invalid}, oc_trace_context_binary:decode(InvalidSpanIdBinary)).
+
 
 decode_with_extra_junk(_Config) ->
     %% TraceId: 85409434994488837557643013731547696719
@@ -40,8 +51,8 @@ decode_with_extra_junk(_Config) ->
     %% Enabled: true
     Binary = <<0,0,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,1,97,98,99,100,101,102,103,104,2,1>>,
     BinaryWithJunk = <<Binary/binary,23,4,5>>,
-    Decoded = oc_trace_context_binary:decode(BinaryWithJunk),
-    Encoded = oc_trace_context_binary:encode(Decoded),
+    {ok, Decoded} = oc_trace_context_binary:decode(BinaryWithJunk),
+    {ok, Encoded} = oc_trace_context_binary:encode(Decoded),
 
     ?assertMatch(Binary, Encoded).
 
@@ -50,7 +61,44 @@ encode_decode_headers(_Config) ->
     %% SpanId: 00f067aa0ba902b7
     %% Enabled: true
     Header = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01">>,
-    Decoded = oc_trace_context_headers:decode(Header),
-    Encoded = oc_trace_context_headers:encode(Decoded),
+    {ok, Decoded} = oc_trace_context_headers:decode(Header),
+    {ok, Encoded} = oc_trace_context_headers:encode(Decoded),
     ?assertEqual(Header, list_to_binary(Encoded)),
-    ?assertEqual(Decoded, oc_trace_context_headers:decode(Encoded)).
+    ?assertEqual({ok, Decoded}, oc_trace_context_headers:decode(Encoded)),
+
+    %% TraceId: 4bf92f3577b34da6a3ce929d0e0e4736
+    %% SpanId: 00f067aa0ba902b7
+    %% Enabled: false
+    DisabledHeader = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00">>,
+    {ok, DisabledDecoded} = oc_trace_context_headers:decode(DisabledHeader),
+    {ok, DisabledEncoded} = oc_trace_context_headers:encode(DisabledDecoded),
+    ?assertEqual(DisabledHeader, list_to_binary(DisabledEncoded)),
+    ?assertEqual({ok, DisabledDecoded}, oc_trace_context_headers:decode(DisabledEncoded)),
+    ?assertNot(DisabledDecoded#trace_context.enabled),
+
+    %% Decode invalid headers
+    InvalidSpanIdHeader = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-00">>,
+    {error, invalid} = oc_trace_context_headers:decode(InvalidSpanIdHeader),
+
+    InvalidTraceIdHeader = <<"00-00000000000000000000000000000000-00f067aa0ba902b7-00">>,
+    {error, invalid} = oc_trace_context_headers:decode(InvalidTraceIdHeader),
+
+    InvalidBothIdsHeader = <<"00-00000000000000000000000000000000-0000000000000000-00">>,
+    {error, invalid} = oc_trace_context_headers:decode(InvalidBothIdsHeader),
+
+
+    %% Encode invalid trace contexts
+    InvalidTC = #trace_context{trace_id = 0,
+                               span_id = 0,
+                               enabled = false},
+    {error, invalid} = oc_trace_context_headers:encode(InvalidTC),
+
+    InvalidTraceIdTC = #trace_context{trace_id = 85409434994488837557643013731547696719,
+                                      span_id = 0,
+                                      enabled = true},
+    {error, invalid} = oc_trace_context_headers:encode(InvalidTraceIdTC),
+
+    InvalidSpanIdTC = #trace_context{trace_id = 0,
+                                     span_id = 7017280452245743464,
+                                     enabled = false},
+    {error, invalid} = oc_trace_context_headers:encode(InvalidSpanIdTC).


### PR DESCRIPTION
This adds support for encoding and decoding the trace context from an HTTP header, following the spec here https://github.com/TraceContext/tracecontext-spec/blob/master/HTTP_HEADER_FORMAT.md