### PR TITLE
attribute handling and simplify api

### DIFF
--- a/include/opencensus.hrl
+++ b/include/opencensus.hrl
@@ -29,7 +29,7 @@
           %% 128 bit int trace id
           trace_id   :: opencensus:trace_id() | undefined,
           %% name of the span
-          name       :: unicode:chardata(),
+          name       :: unicode:unicode_binary(),
           %% 64 bit int span id
           span_id    :: opencensus:span_id() | undefined,
           %% 64 bit int parent span
@@ -112,6 +112,6 @@
 -record(status, {
           code :: integer(),
           %% developer-facing error message
-          message :: unicode:chardata(),
+          message :: unicode:unicode_binary(),
           details :: [term()]
          }).

--- a/src/opencensus.erl
+++ b/src/opencensus.erl
@@ -88,14 +88,10 @@ start_trace(#trace_context{trace_id=TraceId,
 start_trace(TraceId)  ->
     start_trace(TraceId, undefined, undefined).
 
-start_trace(TraceId, SpanId, true)  ->
+start_trace(TraceId, SpanId, Enabled)  ->
     #trace_context{trace_id = TraceId,
                    span_id = SpanId,
-                   enabled = true};
-start_trace(TraceId, SpanId, _)  ->
-    #trace_context{trace_id = TraceId,
-                   span_id = SpanId,
-                   enabled = true}.
+                   enabled = Enabled}.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/test/ocp_SUITE.erl
+++ b/test/ocp_SUITE.erl
@@ -15,9 +15,11 @@ all() ->
     [multiple_child_spans].
 
 init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(opencensus),
     Config.
 
 end_per_suite(_Config) ->
+    ok = application:stop(opencensus),
     ok.
 
 init_per_testcase(_, Config) ->
@@ -30,11 +32,12 @@ multiple_child_spans(_Config) ->
     SpanName1 = <<"span-1">>,
     SpanName2 = <<"span-2">>,
     SpanName3 = <<"span-3">>,
+    ocp:start_trace(),
     ocp:start_span(SpanName1),
     ?assertMatch(#span{name=SpanName1}, ocp:finish_span()),
     ocp:start_span(SpanName1),
-    ocp:child_span(SpanName2),
-    ocp:child_span(SpanName3),
+    ocp:start_span(SpanName2),
+    ocp:start_span(SpanName3),
     ?assertMatch(#span{name=SpanName3}, ocp:finish_span()),
     ?assertMatch(#span{name=SpanName2}, ocp:finish_span()),
     ocp:finish_span(),

--- a/test/opencensus_SUITE.erl
+++ b/test/opencensus_SUITE.erl
@@ -43,7 +43,7 @@ child_spans(_Config) ->
     Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined),
 
     ChildSpanName1 = <<"child-span-1">>,
-    ChildSpan1 = opencensus:child_span(ChildSpanName1, Span1),
+    ChildSpan1 = opencensus:start_span(ChildSpanName1, Span1),
     ?assertEqual(ChildSpanName1, ChildSpan1#span.name),
     ?assertEqual(Span1#span.span_id, ChildSpan1#span.parent_span_id),
     ChildSpan2 = opencensus:finish_span(ChildSpan1),
@@ -58,7 +58,7 @@ noops(_Config) ->
     Span1 = opencensus:start_span(SpanName1, undefined, undefined),
 
     ChildSpanName1 = <<"child-span-1">>,
-    ChildSpan1 = opencensus:child_span(ChildSpanName1, Span1),
+    ChildSpan1 = opencensus:start_span(ChildSpanName1, Span1),
     ChildSpan2 = opencensus:finish_span(ChildSpan1),
     Span2 = opencensus:finish_span(Span1),
 


### PR DESCRIPTION
The ability to put attributes in the attribute map of a span is added here for `opencensus` and `ocp` modules.

The api for handling the creation of a new trace or starting from an existing trace context is improved as well. Now the api is simply `start_trace` and `start_span`, `child_span` is removed. At the beginning of a process boundary `start_trace` is meant to be used to pass an existing trace context that may have been passed along from the caller or creating a completely new trace. There are no samplers yet so `enabled` is always true. 

In `ocp` if a span does not exist when `start_span` is called the trace context is used to start the new span.