### PR TITLE
add finished span handling that buffers and sends to reporter

### DIFF
--- a/src/oc_noop_reporter.erl
+++ b/src/oc_noop_reporter.erl
@@ -1,0 +1,27 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2017, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc A no-op reporter that does nothing.
+%% @end
+%%%-----------------------------------------------------------------------
+-module(oc_noop_reporter).
+
+-export([init/1,
+         report/2]).
+
+init(_Opts) ->
+    #{}.
+
+report(_Spans, _Opts) ->
+    ok.

--- a/src/oc_report_buffer.erl
+++ b/src/oc_report_buffer.erl
@@ -1,0 +1,114 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2017, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Buffer of trace spans to be reported.
+%% @end
+%%%-----------------------------------------------------------------------
+-module(oc_report_buffer).
+
+-behaviour(gen_server).
+
+-export([start_link/0,
+         store_span/1]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2]).
+
+-include("opencensus.hrl").
+
+-record(state, {reporter :: module(),
+                reporter_config :: #{},
+                send_interval_ms :: integer(),
+                timer_ref :: reference()}).
+
+-define(BUFFER_1, oc_report_buffer1).
+-define(BUFFER_2, oc_report_buffer2).
+-define(BUFFER_STATUS, oc_report_status).
+
+start_link() ->
+    maybe_init_ets(),
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec store_span(opencensus:span()) -> ok | {error, invalid_span}.
+store_span(Span=#span{}) ->
+    [{_, Buffer}] = ets:lookup(?BUFFER_STATUS, current_buffer),
+    ets:insert(Buffer, Span);
+store_span(_) ->
+    {error, invalid_span}.
+
+init(_Args) ->
+    SendInterval = application:get_env(opencensus, send_interval_ms, 500),
+    {Reporter, ReporterOpts} = application:get_env(opencensus, reporter, {oc_noop_reporter, []}),
+    ReporterConfig = Reporter:init(ReporterOpts),
+    Ref = erlang:send_after(SendInterval, self(), report_spans),
+    {ok, #state{reporter=Reporter,
+                reporter_config=ReporterConfig,
+                send_interval_ms=SendInterval,
+                timer_ref=Ref}}.
+
+handle_call(_, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+handle_info(report_spans, State=#state{reporter=Reporter,
+                                       reporter_config=Config,
+                                       send_interval_ms=SendInterval,
+                                       timer_ref=Ref}) ->
+    erlang:cancel_timer(Ref),
+    Ref1 = erlang:send_after(SendInterval, self(), report_spans),
+    send_spans(Reporter, Config),
+    {noreply, State#state{timer_ref=Ref1}}.
+
+terminate(_, #state{timer_ref=Ref}) ->
+    erlang:cancel_timer(Ref),
+    ok.
+
+maybe_init_ets() ->
+    case ets:info(?BUFFER_STATUS, name) of
+        undefined ->
+            [ets:new(Tab, [named_table, public | TableProps ]) ||
+                {Tab, TableProps} <- [{?BUFFER_1, [{write_concurrency, true}, {keypos, 2}]},
+                                      {?BUFFER_2, [{write_concurrency, true}, {keypos, 2}]},
+                                      {?BUFFER_STATUS, [{read_concurrency, true}]}]],
+            ets:insert(?BUFFER_STATUS, {current_buffer, ?BUFFER_1});
+        _ ->
+            ok
+    end.
+
+send_spans(Reporter, Config) ->
+    [{_, Buffer}] = ets:lookup(?BUFFER_STATUS, current_buffer),
+    NewBuffer = case Buffer of
+                    ?BUFFER_1 ->
+                        ?BUFFER_2;
+                    ?BUFFER_2 ->
+                        ?BUFFER_1
+                end,
+    ets:insert(?BUFFER_STATUS, {current_buffer, NewBuffer}),
+    case ets:tab2list(Buffer) of
+        [] ->
+            ok;
+        Spans ->
+            ets:delete_all_objects(Buffer),
+            report(Reporter, Spans, Config)
+    end.
+
+report(undefined, _, _) ->
+    ok;
+report(Reporter, Spans, Config) ->
+    Reporter:report(Spans, Config).

--- a/src/opencensus.app.src
+++ b/src/opencensus.app.src
@@ -7,8 +7,8 @@
    [kernel,
     stdlib
    ]},
-  {env,[]},
   {modules, []},
+  {env, [{send_interval_ms, 500}]},
 
   {maintainers, ["Tristan Sloughter"]},
   {licenses, ["Apache 2.0"]},

--- a/src/opencensus.erl
+++ b/src/opencensus.erl
@@ -130,8 +130,10 @@ finish_span(undefined) ->
     undefined;
 finish_span(Span=#span{start_time=StartTime}) ->
     EndTime = wts:timestamp(),
-    Span#span{end_time = EndTime,
-              duration = wts:duration(StartTime, EndTime)}.
+    Span1 = Span#span{end_time = EndTime,
+                      duration = wts:duration(StartTime, EndTime)},
+    _ = oc_report_buffer:store_span(Span1),
+    Span1.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/opencensus_sup.erl
+++ b/src/opencensus_sup.erl
@@ -30,4 +30,12 @@ start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
 init([]) ->
-    {ok, {{one_for_all, 0, 1}, []}}.
+    Reporter = #{id => oc_report_buffer,
+                 start => {oc_report_buffer, start_link, []},
+                 restart => permanent,
+                 shutdown => 1000,
+                 type => worker,
+                 modules => [oc_report_buffer]},
+    {ok, {#{strategy => one_for_one,
+            intensity => 1,
+            period => 5}, [Reporter]}}.

--- a/test/oc_pid_reporter.erl
+++ b/test/oc_pid_reporter.erl
@@ -1,0 +1,29 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2017, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc A test reporter for sending trace spans to an Erlang PID as message.
+%% @end
+%%%-----------------------------------------------------------------------
+-module(oc_pid_reporter).
+
+-export([init/1,
+         report/2]).
+
+init(_) ->
+    application:get_env(opencensus, pid_reporter, #{}).
+
+report(Spans, Opts) ->
+    Pid = maps:get(pid, Opts),
+    [Pid ! {span, Span} || Span <- Spans],
+    ok.

--- a/test/oc_reporters_SUITE.erl
+++ b/test/oc_reporters_SUITE.erl
@@ -1,0 +1,54 @@
+%%% ---------------------------------------------------------------------------
+%%% @doc
+%%% @end
+%%% ---------------------------------------------------------------------------
+-module(oc_reporters_SUITE).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include("opencensus.hrl").
+
+all() ->
+    [pid_reporter].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+pid_reporter(_Config) ->
+    ok = application:load(opencensus),
+    application:set_env(opencensus, reporter, {oc_pid_reporter, []}),
+    application:set_env(opencensus, pid_reporter, #{pid => self()}),
+
+    {ok, _} = application:ensure_all_started(opencensus),
+
+    SpanName1 = <<"span-1">>,
+    Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined),
+
+    ChildSpanName1 = <<"child-span-1">>,
+    ChildSpan1 = opencensus:start_span(ChildSpanName1, Span1),
+    ?assertEqual(ChildSpanName1, ChildSpan1#span.name),
+    ?assertEqual(Span1#span.span_id, ChildSpan1#span.parent_span_id),
+    opencensus:finish_span(ChildSpan1),
+    opencensus:finish_span(Span1),
+
+    %% Order the spans are reported is undefined, so use a selective receive to make
+    %% sure we get them all
+    lists:foreach(fun(Name) ->
+                      receive
+                          {span, S=#span{name = Name}} ->
+                              %% Verify the end time and duration are set when the span was finished
+                              ?assertMatch({ST, O} when is_integer(ST)
+                                                      andalso is_integer(O), S#span.start_time),
+                              ?assertMatch({ST, O} when is_integer(ST)
+                                                      andalso is_integer(O), S#span.end_time),
+                              ?assert(is_integer(S#span.duration))
+                      end
+                  end, [SpanName1, ChildSpanName1]),
+
+    ok = application:stop(opencensus).


### PR DESCRIPTION
The report buffer is a set of ETS tables for storing finished spans that are then flushed and sent to the configured reporter every SendInterval ms after the last reporting.