### PR TITLE
Elvis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,22 @@ jobs:
       - run:
           command: rebar3 xref
 
+  lint:
+    <<: *defaults
+    steps:
+      - checkout
+
+      - attach_workspace:
+          at: /home/circleci/census
+
+      - restore_cache:
+          keys:
+            - census-{{ checksum "rebar.lock" }}
+            - census-hex-packages
+
+      - run:
+          command: rebar3 as lint lint
+
   tests:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,9 @@ workflows:
       - xref:
           requires:
             - build
+      - lint:
+          requires:
+            - build
       - tests:
           requires:
             - build

--- a/elvis.config
+++ b/elvis.config
@@ -1,0 +1,43 @@
+[
+ {
+   elvis,
+   [
+    {config,
+     [#{dirs => ["src"],
+        filter => "*.erl",
+        rules => [{elvis_style, god_modules, #{ignore => [egithub]}},
+                  {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+                  {elvis_style, line_length, #{limit => 120}},
+                  {elvis_style, state_record_and_type, disable}],
+        ruleset => erl_files
+       },
+       #{dirs => ["test"],
+        filter => "*.erl",
+        rules => [{elvis_style, god_modules, #{ignore => [egithub]}},
+                  {elvis_style, dont_repeat_yourself, #{min_complexity => 30}},
+                  {elvis_style, line_length, #{limit => 120}},
+                  %% be a bit more lax on naming for tests
+                  {elvis_style, variable_naming_convention, #{regex => "^_{0,2}([A-Z][0-9a-zA-Z]*)$"}},
+                  {elvis_style, state_record_and_type, disable}],
+        ruleset => erl_files
+      },
+      #{dirs => ["."],
+        filter => "Makefile",
+        rules => [{elvis_project,
+                   protocol_for_deps_erlang_mk,
+                   #{regex => "(https://.*|[0-9]+([.][0-9]+)*)"}}],
+        ruleset => makefiles
+       },
+      #{dirs => ["."],
+        filter => "rebar.config",
+        ruleset => rebar_config
+       },
+      #{dirs => ["."],
+        filter => "elvis.config",
+        ruleset => elvis_config
+       }
+     ]
+    }
+   ]
+ }
+].

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,9 @@
 
 {deps, [{wts, "~> 0.1"}]}.
 
-{profiles, [{test, [{erl_opts, [nowarn_export_all]}]}]}.
+{profiles, [
+  {test, [{erl_opts, [nowarn_export_all]}]},
+  {lint,  [{plugins, [rebar3_lint]}]}]}.
 
 {xref_checks, [undefined_function_calls, undefined_functions,
                deprecated_function_calls, deprecated_functions]}.

--- a/src/oc_trace_context_binary.erl
+++ b/src/oc_trace_context_binary.erl
@@ -43,21 +43,21 @@ encode(#trace_context{trace_id=TraceId,
 
 -spec decode(binary()) -> {ok, opencensus:trace_context()} | {error, invalid}.
 decode(<<0:8/integer, VersionFormat/binary>>) ->
-    decode_0(VersionFormat, #trace_context{}).
+    decode_v0(VersionFormat, #trace_context{}).
 
-decode_0(<<>>, TraceContext) ->
+decode_v0(<<>>, TraceContext) ->
     {ok, TraceContext};
-decode_0(<<?TRACE_ID_FIELD_NUM:8/signed-integer, TraceId:128/integer, _/binary>>, _)
+decode_v0(<<?TRACE_ID_FIELD_NUM:8/signed-integer, TraceId:128/integer, _/binary>>, _)
   when TraceId =:= 0 ->
     {error, invalid};
-decode_0(<<?TRACE_ID_FIELD_NUM:8/signed-integer, TraceId:128/integer, Rest/binary>>, TraceContext) ->
-    decode_0(Rest, TraceContext#trace_context{trace_id=TraceId});
-decode_0(<<?SPAN_ID_FIELD_NUM:8/signed-integer, SpanId:64/integer, _/binary>>, _)
+decode_v0(<<?TRACE_ID_FIELD_NUM:8/signed-integer, TraceId:128/integer, Rest/binary>>, TraceContext) ->
+    decode_v0(Rest, TraceContext#trace_context{trace_id=TraceId});
+decode_v0(<<?SPAN_ID_FIELD_NUM:8/signed-integer, SpanId:64/integer, _/binary>>, _)
   when SpanId =:= 0 ->
     {error, invalid};
-decode_0(<<?SPAN_ID_FIELD_NUM:8/signed-integer, SpanId:64/integer, Rest/binary>>, TraceContext) ->
-    decode_0(Rest, TraceContext#trace_context{span_id=SpanId});
-decode_0(<<?TRACE_OPTIONS_FIELD_NUM:8/signed-integer, _TraceOptions:7, Enabled:1, Rest/binary>>, TraceContext) ->
-    decode_0(Rest, TraceContext#trace_context{enabled=case Enabled of 1 -> true; _ -> false end});
-decode_0(_, TraceContext) ->
+decode_v0(<<?SPAN_ID_FIELD_NUM:8/signed-integer, SpanId:64/integer, Rest/binary>>, TraceContext) ->
+    decode_v0(Rest, TraceContext#trace_context{span_id=SpanId});
+decode_v0(<<?TRACE_OPTIONS_FIELD_NUM:8/signed-integer, _TraceOptions:7, Enabled:1, Rest/binary>>, TraceContext) ->
+    decode_v0(Rest, TraceContext#trace_context{enabled=case Enabled of 1 -> true; _ -> false end});
+decode_v0(_, TraceContext) ->
     {ok, TraceContext}.

--- a/test/oc_trace_context_SUITE.erl
+++ b/test/oc_trace_context_SUITE.erl
@@ -12,7 +12,7 @@
 -include("opencensus.hrl").
 
 all() ->
-    [encode_decode, decode_with_extra_junk, encode_decode_headers].
+    [encode_decode,  decode_with_extra_junk,  encode_decode_headers].
 
 init_per_suite(Config) ->
     Config.
@@ -20,83 +20,86 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_testcase(_, Config) ->
+init_per_testcase(_,  Config) ->
     Config.
 
-end_per_testcase(_, _Config) ->
+end_per_testcase(_,  _Config) ->
     ok.
 
+%% TraceId: 85409434994488837557643013731547696719
+%% SpanId: 7017280452245743464
+%% Enabled: true
+-define(EXAMPLE_BIN, <<0, 0, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78,
+        79, 1, 97, 98, 99, 100, 101, 102, 103, 104, 2, 1>>).
+
+reencode(Binary) ->
+    {ok,  Decoded} = oc_trace_context_binary:decode(Binary),
+    {ok,  Encoded} = oc_trace_context_binary:encode(Decoded),
+    Encoded.
+
 encode_decode(_Config) ->
-    %% TraceId: 85409434994488837557643013731547696719
-    %% SpanId: 7017280452245743464
-    %% Enabled: true
-    Binary = <<0,0,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,1,97,98,99,100,101,102,103,104,2,1>>,
-    {ok, Decoded} = oc_trace_context_binary:decode(Binary),
-    {ok, Encoded} = oc_trace_context_binary:encode(Decoded),
-    ?assertMatch(Binary, Encoded),
+    Encoded = reencode(?EXAMPLE_BIN),
 
-    InvalidBothIdsBinary = <<0:8,0:8,0:128,1:8,0:64,2:8,1>>,
-    ?assertEqual({error, invalid}, oc_trace_context_binary:decode(InvalidBothIdsBinary)),
+    ?assertMatch(?EXAMPLE_BIN,  Encoded),
 
-    InvalidTraceIdBinary = <<0:8,0:8,0:128,1:8,1:64,2:8,1>>,
-    ?assertEqual({error, invalid}, oc_trace_context_binary:decode(InvalidTraceIdBinary)),
+    InvalidBothIdsBinary = <<0:8, 0:8, 0:128, 1:8, 0:64, 2:8, 1>>,
+    ?assertEqual({error,  invalid},  oc_trace_context_binary:decode(InvalidBothIdsBinary)),
 
-    InvalidSpanIdBinary = <<0:8,0:8,1:128,1:8,0:64,2:8,1>>,
-    ?assertEqual({error, invalid}, oc_trace_context_binary:decode(InvalidSpanIdBinary)).
+    InvalidTraceIdBinary = <<0:8, 0:8, 0:128, 1:8, 1:64, 2:8, 1>>,
+    ?assertEqual({error,  invalid},  oc_trace_context_binary:decode(InvalidTraceIdBinary)),
+
+    InvalidSpanIdBinary = <<0:8, 0:8, 1:128, 1:8, 0:64, 2:8, 1>>,
+    ?assertEqual({error,  invalid},  oc_trace_context_binary:decode(InvalidSpanIdBinary)).
 
 
 decode_with_extra_junk(_Config) ->
-    %% TraceId: 85409434994488837557643013731547696719
-    %% SpanId: 7017280452245743464
-    %% Enabled: true
-    Binary = <<0,0,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,1,97,98,99,100,101,102,103,104,2,1>>,
-    BinaryWithJunk = <<Binary/binary,23,4,5>>,
-    {ok, Decoded} = oc_trace_context_binary:decode(BinaryWithJunk),
-    {ok, Encoded} = oc_trace_context_binary:encode(Decoded),
+    Binary = ?EXAMPLE_BIN,
+    BinaryWithJunk = <<Binary/binary, 23, 4, 5>>,
+    Encoded = reencode(BinaryWithJunk),
 
-    ?assertMatch(Binary, Encoded).
+    ?assertMatch(Binary,  Encoded).
 
 encode_decode_headers(_Config) ->
     %% TraceId: 4bf92f3577b34da6a3ce929d0e0e4736
     %% SpanId: 00f067aa0ba902b7
     %% Enabled: true
     Header = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01">>,
-    {ok, Decoded} = oc_trace_context_headers:decode(Header),
-    {ok, Encoded} = oc_trace_context_headers:encode(Decoded),
-    ?assertEqual(Header, list_to_binary(Encoded)),
-    ?assertEqual({ok, Decoded}, oc_trace_context_headers:decode(Encoded)),
+    {ok,  Decoded} = oc_trace_context_headers:decode(Header),
+    {ok,  Encoded} = oc_trace_context_headers:encode(Decoded),
+    ?assertEqual(Header,  list_to_binary(Encoded)),
+    ?assertEqual({ok,  Decoded},  oc_trace_context_headers:decode(Encoded)),
 
     %% TraceId: 4bf92f3577b34da6a3ce929d0e0e4736
     %% SpanId: 00f067aa0ba902b7
     %% Enabled: false
     DisabledHeader = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00">>,
-    {ok, DisabledDecoded} = oc_trace_context_headers:decode(DisabledHeader),
-    {ok, DisabledEncoded} = oc_trace_context_headers:encode(DisabledDecoded),
-    ?assertEqual(DisabledHeader, list_to_binary(DisabledEncoded)),
-    ?assertEqual({ok, DisabledDecoded}, oc_trace_context_headers:decode(DisabledEncoded)),
+    {ok,  DisabledDecoded} = oc_trace_context_headers:decode(DisabledHeader),
+    {ok,  DisabledEncoded} = oc_trace_context_headers:encode(DisabledDecoded),
+    ?assertEqual(DisabledHeader,  list_to_binary(DisabledEncoded)),
+    ?assertEqual({ok,  DisabledDecoded},  oc_trace_context_headers:decode(DisabledEncoded)),
     ?assertNot(DisabledDecoded#trace_context.enabled),
 
     %% Decode invalid headers
     InvalidSpanIdHeader = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-00">>,
-    {error, invalid} = oc_trace_context_headers:decode(InvalidSpanIdHeader),
+    {error,  invalid} = oc_trace_context_headers:decode(InvalidSpanIdHeader),
 
     InvalidTraceIdHeader = <<"00-00000000000000000000000000000000-00f067aa0ba902b7-00">>,
-    {error, invalid} = oc_trace_context_headers:decode(InvalidTraceIdHeader),
+    {error,  invalid} = oc_trace_context_headers:decode(InvalidTraceIdHeader),
 
     InvalidBothIdsHeader = <<"00-00000000000000000000000000000000-0000000000000000-00">>,
-    {error, invalid} = oc_trace_context_headers:decode(InvalidBothIdsHeader),
+    {error,  invalid} = oc_trace_context_headers:decode(InvalidBothIdsHeader),
 
 
     %% Encode invalid trace contexts
     InvalidTC = #trace_context{trace_id = 0,
                                span_id = 0,
                                enabled = false},
-    {error, invalid} = oc_trace_context_headers:encode(InvalidTC),
+    {error,  invalid} = oc_trace_context_headers:encode(InvalidTC),
 
     InvalidTraceIdTC = #trace_context{trace_id = 85409434994488837557643013731547696719,
                                       span_id = 0,
                                       enabled = true},
-    {error, invalid} = oc_trace_context_headers:encode(InvalidTraceIdTC),
+    {error,  invalid} = oc_trace_context_headers:encode(InvalidTraceIdTC),
 
     InvalidSpanIdTC = #trace_context{trace_id = 0,
                                      span_id = 7017280452245743464,

--- a/test/oc_trace_context_SUITE.erl
+++ b/test/oc_trace_context_SUITE.erl
@@ -12,7 +12,7 @@
 -include("opencensus.hrl").
 
 all() ->
-    [encode_decode,  decode_with_extra_junk,  encode_decode_headers].
+    [encode_decode, decode_with_extra_junk, encode_decode_headers].
 
 init_per_suite(Config) ->
     Config.
@@ -20,10 +20,10 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_testcase(_,  Config) ->
+init_per_testcase(_, Config) ->
     Config.
 
-end_per_testcase(_,  _Config) ->
+end_per_testcase(_, _Config) ->
     ok.
 
 %% TraceId: 85409434994488837557643013731547696719
@@ -33,23 +33,23 @@ end_per_testcase(_,  _Config) ->
         79, 1, 97, 98, 99, 100, 101, 102, 103, 104, 2, 1>>).
 
 reencode(Binary) ->
-    {ok,  Decoded} = oc_trace_context_binary:decode(Binary),
-    {ok,  Encoded} = oc_trace_context_binary:encode(Decoded),
+    {ok, Decoded} = oc_trace_context_binary:decode(Binary),
+    {ok, Encoded} = oc_trace_context_binary:encode(Decoded),
     Encoded.
 
 encode_decode(_Config) ->
     Encoded = reencode(?EXAMPLE_BIN),
 
-    ?assertMatch(?EXAMPLE_BIN,  Encoded),
+    ?assertMatch(?EXAMPLE_BIN, Encoded),
 
     InvalidBothIdsBinary = <<0:8, 0:8, 0:128, 1:8, 0:64, 2:8, 1>>,
-    ?assertEqual({error,  invalid},  oc_trace_context_binary:decode(InvalidBothIdsBinary)),
+    ?assertEqual({error, invalid}, oc_trace_context_binary:decode(InvalidBothIdsBinary)),
 
     InvalidTraceIdBinary = <<0:8, 0:8, 0:128, 1:8, 1:64, 2:8, 1>>,
-    ?assertEqual({error,  invalid},  oc_trace_context_binary:decode(InvalidTraceIdBinary)),
+    ?assertEqual({error, invalid}, oc_trace_context_binary:decode(InvalidTraceIdBinary)),
 
     InvalidSpanIdBinary = <<0:8, 0:8, 1:128, 1:8, 0:64, 2:8, 1>>,
-    ?assertEqual({error,  invalid},  oc_trace_context_binary:decode(InvalidSpanIdBinary)).
+    ?assertEqual({error, invalid}, oc_trace_context_binary:decode(InvalidSpanIdBinary)).
 
 
 decode_with_extra_junk(_Config) ->
@@ -57,49 +57,49 @@ decode_with_extra_junk(_Config) ->
     BinaryWithJunk = <<Binary/binary, 23, 4, 5>>,
     Encoded = reencode(BinaryWithJunk),
 
-    ?assertMatch(Binary,  Encoded).
+    ?assertMatch(Binary, Encoded).
 
 encode_decode_headers(_Config) ->
     %% TraceId: 4bf92f3577b34da6a3ce929d0e0e4736
     %% SpanId: 00f067aa0ba902b7
     %% Enabled: true
     Header = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01">>,
-    {ok,  Decoded} = oc_trace_context_headers:decode(Header),
-    {ok,  Encoded} = oc_trace_context_headers:encode(Decoded),
-    ?assertEqual(Header,  list_to_binary(Encoded)),
-    ?assertEqual({ok,  Decoded},  oc_trace_context_headers:decode(Encoded)),
+    {ok, Decoded} = oc_trace_context_headers:decode(Header),
+    {ok, Encoded} = oc_trace_context_headers:encode(Decoded),
+    ?assertEqual(Header, list_to_binary(Encoded)),
+    ?assertEqual({ok, Decoded}, oc_trace_context_headers:decode(Encoded)),
 
     %% TraceId: 4bf92f3577b34da6a3ce929d0e0e4736
     %% SpanId: 00f067aa0ba902b7
     %% Enabled: false
     DisabledHeader = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00">>,
-    {ok,  DisabledDecoded} = oc_trace_context_headers:decode(DisabledHeader),
-    {ok,  DisabledEncoded} = oc_trace_context_headers:encode(DisabledDecoded),
-    ?assertEqual(DisabledHeader,  list_to_binary(DisabledEncoded)),
-    ?assertEqual({ok,  DisabledDecoded},  oc_trace_context_headers:decode(DisabledEncoded)),
+    {ok, DisabledDecoded} = oc_trace_context_headers:decode(DisabledHeader),
+    {ok, DisabledEncoded} = oc_trace_context_headers:encode(DisabledDecoded),
+    ?assertEqual(DisabledHeader, list_to_binary(DisabledEncoded)),
+    ?assertEqual({ok, DisabledDecoded}, oc_trace_context_headers:decode(DisabledEncoded)),
     ?assertNot(DisabledDecoded#trace_context.enabled),
 
     %% Decode invalid headers
     InvalidSpanIdHeader = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-00">>,
-    {error,  invalid} = oc_trace_context_headers:decode(InvalidSpanIdHeader),
+    {error, invalid} = oc_trace_context_headers:decode(InvalidSpanIdHeader),
 
     InvalidTraceIdHeader = <<"00-00000000000000000000000000000000-00f067aa0ba902b7-00">>,
-    {error,  invalid} = oc_trace_context_headers:decode(InvalidTraceIdHeader),
+    {error, invalid} = oc_trace_context_headers:decode(InvalidTraceIdHeader),
 
     InvalidBothIdsHeader = <<"00-00000000000000000000000000000000-0000000000000000-00">>,
-    {error,  invalid} = oc_trace_context_headers:decode(InvalidBothIdsHeader),
+    {error, invalid} = oc_trace_context_headers:decode(InvalidBothIdsHeader),
 
 
     %% Encode invalid trace contexts
     InvalidTC = #trace_context{trace_id = 0,
                                span_id = 0,
                                enabled = false},
-    {error,  invalid} = oc_trace_context_headers:encode(InvalidTC),
+    {error, invalid} = oc_trace_context_headers:encode(InvalidTC),
 
     InvalidTraceIdTC = #trace_context{trace_id = 85409434994488837557643013731547696719,
                                       span_id = 0,
                                       enabled = true},
-    {error,  invalid} = oc_trace_context_headers:encode(InvalidTraceIdTC),
+    {error, invalid} = oc_trace_context_headers:encode(InvalidTraceIdTC),
 
     InvalidSpanIdTC = #trace_context{trace_id = 0,
                                      span_id = 7017280452245743464,


### PR DESCRIPTION
Adds an elvis config and some cleanup of the suite to not vomit all over the place and hide issues that might be worth discussing.

The linter does not pass on this point, this is on purpose as we should discuss if what rules we want to impose plus 2 errors are based on missing callbacks.

remaining errors:
```
# src/oc_report_buffer.erl [FAIL]
  - invalid_dynamic_call
    - Remove the dynamic function call on line 57. Only modules that define callbacks should make dynamic calls.
    - Remove the dynamic function call on line 118. Only modules that define callbacks should make dynamic calls.
# src/oc_trace_context_binary.erl [FAIL]
  - function_naming_convention
    - The function "decode_0" does not respect the format defined by the regular expression '"^([a-z][a-z0-9]*_?)*$"'.
```

