### PR TITLE
Make default namespace explicit for erl_vsn hook.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {deps, [{wts, "~> 0.3"}]}.
 
 {plugins, [{rebar_erl_vsn, "~> 0.1"}]}.
-{provider_hooks, [{pre, [{compile, erl_vsn}]}]}.
+{provider_hooks, [{pre, [{compile, {default, erl_vsn}}]}]}.
 
 {profiles, [
   {test, [{erl_opts, [nowarn_export_all]}]},


### PR DESCRIPTION
Without this opencensus-erlang can't be compiled by mix, really interesting...

Before

```
===> Evaluating config script "rebar.config.script"
===> Evaluating config script "<path>/opencensus-erlang-prometheus/deps/opencensus/_build/default/plugins/coveralls/rebar.config.script"
===> Evaluating config script "<path>/opencensus-erlang-prometheus/deps/opencensus/_build/default/plugins/coveralls/rebar.config.script"
===> Expanded command sequence to be run: []
===> Expanded command sequence to be run: [{default,app_discovery},
                                                  {bare,compile}]
===> Evaluating config script "<path>/opencensus-erlang-prometheus/deps/opencensus/rebar.config.script"
===> Not adding provider default erl_vsn from module rebar_erl_vsn_prv because it already exists from module rebar_erl_vsn_prv
===> Evaluating config script "<path>/opencensus-erlang-prometheus/deps/opencensus/rebar.config.script"
===> Not adding provider default erl_vsn from module rebar_erl_vsn_prv because it already exists from module rebar_erl_vsn_prv
===> Compiling opencensus
===> Unable to run pre hooks for 'compile', command 'erl_vsn' not found.
===> Unable to run pre hooks for 'compile', command 'erl_vsn' not found.
** (Mix) Could not compile dependency :opencensus, "DEBUG=1 <path>/rebar3 bare compile --paths "<path>/opencensus-erlang-prometheus/_build/dev/lib/*/ebin"" command failed. You can recompile this dependency with "mix deps.compile opencensus", update it with "mix deps.update opencensus" or clean it with "mix deps.clean opencensus"
```

After

```
===> Evaluating config script "rebar.config.script"
===> Evaluating config script "<path>/opencensus-erlang-prometheus/deps/opencensus/_build/default/plugins/coveralls/rebar.config.script"
===> Evaluating config script "<path>/opencensus-erlang-prometheus/deps/opencensus/_build/default/plugins/coveralls/rebar.config.script"
===> Expanded command sequence to be run: []
===> Expanded command sequence to be run: [{default,app_discovery},
                                                  {bare,compile}]
===> Evaluating config script "<path>/opencensus-erlang-prometheus/deps/opencensus/rebar.config.script"
===> Not adding provider default erl_vsn from module rebar_erl_vsn_prv because it already exists from module rebar_erl_vsn_prv
===> Evaluating config script "<path>/opencensus-erlang-prometheus/deps/opencensus/rebar.config.script"
===> Not adding provider default erl_vsn from module rebar_erl_vsn_prv because it already exists from module rebar_erl_vsn_prv
===> Compiling opencensus
===> run_hooks("<path>/opencensus-erlang-prometheus/deps/opencensus", pre_hooks, compile) -> no hooks defined

===> run_hooks("<path>/opencensus-erlang-prometheus/deps/opencensus", pre_hooks, erlc_compile) -> no hooks defined

===> erlopts [debug_info,
                     {d,'14.0'},
                     {d,'14.1'},
                     {d,'14.2'},
                     {d,'14.3'},
                     {d,'14.4'},
                     {d,'15.0'},
                     {d,'15.1'},
                     {d,'15.2'},
<truncated>
```