### PR TITLE
Use native time units for span duration

### DIFF
--- a/include/opencensus.hrl
+++ b/include/opencensus.hrl
@@ -34,7 +34,7 @@
           span_id    :: opencensus:span_id() | undefined,
           %% 64 bit int parent span
           parent_span_id  :: opencensus:span_id() | undefined,
-          %% microseconds between span start/end
+          %% native time units between span start/end
           duration   :: opencensus:time_us(),
 
           annotations :: opencensus:annotations(),

--- a/src/opencensus.erl
+++ b/src/opencensus.erl
@@ -132,7 +132,7 @@ finish_span(undefined) ->
 finish_span(Span=#span{start_time=StartTime}) ->
     EndTime = wts:timestamp(),
     Span1 = Span#span{end_time = EndTime,
-                      duration = wts:duration(StartTime, EndTime)},
+                      duration = duration(StartTime, EndTime)},
     _ = oc_reporter:store_span(Span1),
     Span1.
 
@@ -213,3 +213,7 @@ uniform(X) ->
     R = rand:uniform(?TWO_POW_56),
     (uniform(X bsr 56) bsl 56) + R.
 -endif.
+
+-spec duration(wts:timestamp(), wts:timestamp()) -> integer().
+duration({Timestamp1, _}, {Timestamp2, _}) ->
+    Timestamp2 - Timestamp1.


### PR DESCRIPTION
Reporters can do conversion if needed.

Example [from prometheus reporter](https://github.com/deadtrickster/opencensus-erlang-prometheus/blob/46428088b70273cf43440a33094de4c94bc5d08e/src/oc_prometheus_reporter.erl#L62):

```erlang
  Type:observe(MetricName, Labels, Span#span.duration).
```