### PR TITLE
Can set span attributes directly in start_span/3

### DIFF
--- a/src/opencensus.erl
+++ b/src/opencensus.erl
@@ -23,6 +23,7 @@
 
          start_span/2,
          start_span/3,
+         start_span/4,
          finish_span/1,
 
          context/1,
@@ -103,15 +104,25 @@ start_span(_Name, undefined) ->
     undefined;
 start_span(Name, #trace_context{trace_id=TraceId,
                                 span_id=ParentId}) ->
-    start_span(Name, TraceId, ParentId);
+    start_span(Name, TraceId, ParentId, #{});
 start_span(Name, #span{trace_id=TraceId,
                        span_id=ParentId}) ->
-    start_span(Name, TraceId, ParentId).
+    start_span(Name, TraceId, ParentId, #{}).
 
--spec start_span(unicode:unicode_binary(), maybe(trace_id()), maybe(span_id())) -> maybe(span()).
-start_span(_Name, undefined, undefined) ->
+-spec start_span(unicode:unicode_binary(), maybe(trace_context() | span()), map()) -> maybe(span()).
+start_span(_Name, undefined, _) ->
     undefined;
-start_span(Name, TraceId, ParentId) when is_integer(TraceId)
+start_span(Name, #trace_context{trace_id=TraceId,
+                                span_id=ParentId}, Attributes) ->
+    start_span(Name, TraceId, ParentId, Attributes);
+start_span(Name, #span{trace_id=TraceId,
+                       span_id=ParentId}, Attributes) ->
+    start_span(Name, TraceId, ParentId, Attributes).
+
+-spec start_span(unicode:unicode_binary(), maybe(trace_id()), maybe(span_id()), map()) -> maybe(span()).
+start_span(_Name, undefined, undefined, _) ->
+    undefined;
+start_span(Name, TraceId, ParentId, Attributes) when is_integer(TraceId)
                                        , (is_integer(ParentId)
                                          orelse ParentId =:= undefined) ->
     #span{start_time = wts:timestamp(),
@@ -119,7 +130,7 @@ start_span(Name, TraceId, ParentId) when is_integer(TraceId)
           span_id = generate_span_id(),
           parent_span_id = ParentId,
           name = Name,
-          attributes = maps:new()}.
+          attributes = Attributes}.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/test/oc_reporters_SUITE.erl
+++ b/test/oc_reporters_SUITE.erl
@@ -41,7 +41,7 @@ end_per_testcase(_, _Config) ->
 
 pid_reporter(_Config) ->
     SpanName1 = <<"span-1">>,
-    Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined),
+    Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined, #{}),
 
     ChildSpanName1 = <<"child-span-1">>,
     ChildSpan1 = opencensus:start_span(ChildSpanName1, Span1),
@@ -65,7 +65,7 @@ pid_reporter(_Config) ->
 
 sequential_reporter(_Config) ->
     SpanName1 = <<"span-1">>,
-    Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined),
+    Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined, #{}),
 
     ChildSpanName1 = <<"child-span-1">>,
     ChildSpan1 = opencensus:start_span(ChildSpanName1, Span1),

--- a/test/opencensus_SUITE.erl
+++ b/test/opencensus_SUITE.erl
@@ -29,7 +29,7 @@ end_per_testcase(_, _Config) ->
 
 start_finish(_Config) ->
     SpanName1 = <<"span-1">>,
-    Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined),
+    Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined, #{}),
     ?assertMatch({T, O} when is_integer(T)
                            andalso is_integer(O), Span1#span.start_time),
 
@@ -40,7 +40,7 @@ start_finish(_Config) ->
 
 child_spans(_Config) ->
     SpanName1 = <<"span-1">>,
-    Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined),
+    Span1 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined, #{}),
 
     ChildSpanName1 = <<"child-span-1">>,
     ChildSpan1 = opencensus:start_span(ChildSpanName1, Span1),
@@ -67,7 +67,10 @@ noops(_Config) ->
 
 attributes_test(_Config) ->
     SpanName1 = <<"span-1">>,
-    Span0 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined),
+    Attributes = #{<<"attr-1">> => <<"value-1">>,
+                   <<"attr-2">> => 123,
+                   <<"attr-3">> => true},
+    Span0 = opencensus:start_span(SpanName1, opencensus:generate_trace_id(), undefined, #{}),
     Span1 = opencensus:put_attribute(<<"attr-0">>, <<"value-0">>, Span0),
 
     ChildSpanName1 = <<"child-span-1">>,
@@ -85,6 +88,11 @@ attributes_test(_Config) ->
     ?assertEqual(<<"value-1">>, maps:get(<<"attr-1">>, ChildSpan5#span.attributes)),
     ?assertEqual(123, maps:get(<<"attr-2">>, ChildSpan5#span.attributes)),
     ?assertEqual(true, maps:get(<<"attr-3">>, ChildSpan5#span.attributes)),
+
+    SpanA1 = opencensus:start_span(ChildSpanName1, Span1, Attributes),
+    SpanA2 = opencensus:start_span(ChildSpanName1, Span1#span.trace_id, Span1#span.span_id, Attributes),
+    ?assertEqual(ChildSpan4#span.attributes, SpanA1#span.attributes),
+    ?assertEqual(ChildSpan4#span.attributes, SpanA2#span.attributes),
 
     Span2 = opencensus:finish_span(Span1),
 


### PR DESCRIPTION
Also `start_span/4` added.

Example [from prometheus reporter tests](https://github.com/deadtrickster/opencensus-erlang-prometheus/blob/master/test/ct/oep_SUITE.erl#L68):

```erlang
opencensus:start_span(SpanName1, opencensus:generate_trace_id(), #{<<"op_name">> => "test"}),
```