### PR TITLE
oc_chain_reporter implementation

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -8,7 +8,9 @@
         rules => [{elvis_style, god_modules, #{ignore => [egithub]}},
                   {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
                   {elvis_style, line_length, #{limit => 120}},
-                  {elvis_style, state_record_and_type, disable}],
+                  {elvis_style, state_record_and_type, disable},
+                  %% sequential reporter calls other reporters dynamically
+                  {elvis_style, invalid_dynamic_call, #{ignore => [oc_sequential_reporter]}}],
         ruleset => erl_files
        },
        #{dirs => ["test"],

--- a/src/oc_reporter.erl
+++ b/src/oc_reporter.erl
@@ -43,7 +43,7 @@
 %% spans that have been collected so far and the configuration returned in `init'.
 %% Do whatever needs to be done to report each span here, the caller will block
 %% until it returns.
--callback report([opencensus:spans()], opts()) -> ok.
+-callback report(nonempty_list(opencensus:span()), opts()) -> ok.
 
 -record(state, {reporter :: module(),
                 reporter_config :: #{},

--- a/src/oc_sequential_reporter.erl
+++ b/src/oc_sequential_reporter.erl
@@ -1,0 +1,38 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2017, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc This module allows sequential execution of multiple reporters.
+%% @end
+%%%-----------------------------------------------------------------------
+-module(oc_sequential_reporter).
+
+-behavior(oc_reporter).
+
+-export([init/1,
+         report/2]).
+
+-type reporter() :: atom().
+-type reporter_opts() :: term().
+-type opts() :: [{reporter(), reporter_opts()}].
+
+%%-
+-spec init([{reporter(), reporter_opts()}]) -> opts().
+init(Config) ->
+    [{Reporter, Reporter:init(RConfig)} || {Reporter, RConfig} <- Config].
+
+%%-
+-spec report(nonempty_list(opencensus:spans()), opts()) -> ok.
+report(Spans, Config) ->
+    [Reporter:report(Spans, RConfig) || {Reporter, RConfig} <- Config],
+    ok.


### PR DESCRIPTION
Simple composite reporter. Gets list of real reporters from its configuration.
Probably needs more error handling (wait for #21?).
Can be optimized using codegen, this left for next iteration.