### PR TITLE
add parse transform to mark function as part of the trace

### DIFF
--- a/src/oc_transform.erl
+++ b/src/oc_transform.erl
@@ -1,0 +1,91 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2017, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc oc_transform provides a parse transform for wrapping a function in
+%% a start and a finish of a span.
+%% @end
+%%%-----------------------------------------------------------------------
+
+-module(oc_transform).
+
+-export([parse_transform/2,
+         format_error/1]).
+
+parse_transform(Ast, _Options)->
+    try lists:mapfoldl(fun form/2, {false, []}, Ast) of
+        {Ast1, _} ->
+            lists:flatten(lists:filter(fun(Node) -> Node =/= nil end, Ast1))
+    catch
+        throw:E ->
+            E
+    end.
+
+form({attribute, _Line, trace, Args}, _) ->
+    {nil, {true, Args}};
+form(Node={function, _Line, _FuncName, _Arity, _Clauses}, {false, []}) ->
+    {Node, {false, []}};
+form(Node={function, _Line, _FuncName, _Arity, _Clauses}, {true, Args}) ->
+    {trace(Node, Args), {false, []}};
+form(Node, Trace) ->
+    {Node, Trace}.
+
+trace({function, Line, Name, Arity, Clauses}, Args) ->
+    case args_proplist(Args) of
+        {error, Reason} ->
+            {error, {Line, ?MODULE, Reason}};
+        ArgsPropList ->
+            SpanName = proplists:get_value(name, ArgsPropList, Name),
+            Clauses1 = trace_clauses(Clauses, SpanName),
+            {function, Line, Name, Arity, Clauses1}
+    end.
+
+trace_clauses([], _) ->
+    [];
+trace_clauses([{clause, Line, H, G, B} | Cs], Name) ->
+    StartSpan = [{call, Line,
+                  {remote, Line, {atom, Line, ocp}, {atom, Line, start_span}},
+                  [{string, Line, to_binary(Name)}]}],
+    FinishSpan = [{call, Line,
+                   {remote, Line, {atom, Line, ocp}, {atom, Line, finish_span}},
+                   []}],
+    Trace = StartSpan ++ [{'try', Line, B, [], [], FinishSpan}],
+    [{clause, Line, H, G, Trace} | trace_clauses(Cs, Name)].
+
+to_binary(X) when is_binary(X) ->
+    X;
+to_binary(X) when is_list(X) ->
+    list_to_binary(X);
+to_binary(X) when is_atom(X) ->
+    atom_to_binary(X, utf8).
+
+args_proplist(A) when is_binary(A) ->
+    [{name, A}];
+args_proplist([]) ->
+    [];
+args_proplist(A) when is_list(A) ->
+    try unicode:characters_to_nfc_binary(A) of
+        B ->
+            [{name, B}]
+    catch
+        %% must not be a string, use as a proplist
+        error:function_clause ->
+            A
+    end;
+args_proplist(A) ->
+    {error, {bad_trace_args, A}}.
+
+format_error({bad_trace_args, Args}) ->
+    io_lib:format("Bad trace arguments. Must be binary or proplist. Got: ~p", [Args]);
+format_error({bad_name, Args}) ->
+    io_lib:format("Bad span name. Name must be a printable binary or list string. Got: ~p", [Args]).

--- a/src/oc_transform.erl
+++ b/src/oc_transform.erl
@@ -71,6 +71,8 @@ to_binary(X) when is_atom(X) ->
 
 args_proplist(A) when is_binary(A) ->
     [{name, A}];
+args_proplist(A) when is_atom(A) ->
+    [{name, A}];
 args_proplist([]) ->
     [];
 args_proplist(A) when is_list(A) ->
@@ -86,6 +88,6 @@ args_proplist(A) ->
     {error, {bad_trace_args, A}}.
 
 format_error({bad_trace_args, Args}) ->
-    io_lib:format("Bad trace arguments. Must be binary or proplist. Got: ~p", [Args]);
+    io_lib:format("Bad trace arguments. Must be binary, atom, list string or proplist. Got: ~p", [Args]);
 format_error({bad_name, Args}) ->
-    io_lib:format("Bad span name. Name must be a printable binary or list string. Got: ~p", [Args]).
+    io_lib:format("Bad span name. Name must be an atom, binary or printable list. Got: ~p", [Args]).

--- a/test/oc_transform_SUITE.erl
+++ b/test/oc_transform_SUITE.erl
@@ -1,0 +1,74 @@
+%%% ---------------------------------------------------------------------------
+%%% @doc
+%%% @end
+%%% ---------------------------------------------------------------------------
+-module(oc_transform_SUITE).
+
+-compile({parse_transform, oc_transform}).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include("opencensus.hrl").
+
+all() ->
+    [trace_transform].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_, Config) ->
+    application:load(opencensus),
+    application:set_env(opencensus, reporter, {oc_pid_reporter, []}),
+    application:set_env(opencensus, pid_reporter, #{pid => self()}),
+
+    {ok, _} = application:ensure_all_started(opencensus),
+
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok = application:stop(opencensus),
+    ok.
+
+trace_transform(_Config) ->
+    SpanName1 = <<"span-1">>,
+    SpanName2 = <<"span-2">>,
+    ocp:start_trace(),
+    ocp:start_span(SpanName1),
+
+    traced_function(),
+
+    ocp:start_span(SpanName2),
+    ?assertMatch(#span{name=SpanName2}, ocp:finish_span()),
+    ?assertMatch(#span{name=SpanName1}, ocp:finish_span()),
+
+    ?assertMatch(undefined, ocp:finish_span()),
+
+    %% verify all spans, including spans for the transform using functions are reported
+    lists:foreach(fun(Name) ->
+                      receive
+                          {span, S=#span{name = Name}} ->
+                              %% Verify the end time and duration are set when the span was finished
+                              ?assertMatch({ST, O} when is_integer(ST)
+                                                      andalso is_integer(O), S#span.start_time),
+                              ?assertMatch({ST, O} when is_integer(ST)
+                                                      andalso is_integer(O), S#span.end_time),
+                              ?assert(is_integer(S#span.duration))
+                      after 1000 ->
+                              error(timeout)
+                      end
+                  end, [SpanName1, <<"traced_function">>, <<"my_name">>, SpanName2]).
+
+
+-trace([]).
+traced_function() ->
+    another_traced_function().
+
+-trace(<<"my_name">>).
+another_traced_function() ->
+    trace_this.

--- a/test/oc_transform_SUITE.erl
+++ b/test/oc_transform_SUITE.erl
@@ -64,7 +64,6 @@ trace_transform(_Config) ->
                       end
                   end, [SpanName1, <<"traced_function">>, <<"my_name">>, SpanName2]).
 
-
 -trace([]).
 traced_function() ->
     another_traced_function().

--- a/test/oc_transform_SUITE.erl
+++ b/test/oc_transform_SUITE.erl
@@ -62,7 +62,7 @@ trace_transform(_Config) ->
                       after 1000 ->
                               error(timeout)
                       end
-                  end, [SpanName1, <<"traced_function">>, <<"my_name">>, SpanName2]).
+                  end, [SpanName1, <<"oc_transform_SUITE:traced_function/0">>, <<"my_name">>, SpanName2]).
 
 -trace([]).
 traced_function() ->


### PR DESCRIPTION
This patch adds a function "decorator" to say a function should be part of a trace (meaning a span created for the start of the function and finished when it completes). It takes a name (list or binary string) or proplist as arguments. 

The list can be empty and then the name is the name of function. This makes for a little odd code in the parsing of the arguments. I considered requiring a map instead of a list to not have the confusion, but then when you just want the default function name you have to use a map instead of an empty list, `-trace(#{}).` vs `-trace([]).`, which just seemed odd. Requiring a binary and returning an error if you put `-trace("span name").` also seemed wrong, since it is telling the user, "I know what you meant, I just don't care".

Open to suggestions.

```
-trace([])
some_function ->
    ... do stuff ...
```