### PR TITLE
Relax attribute values requirements

### DIFF
--- a/src/opencensus.erl
+++ b/src/opencensus.erl
@@ -159,12 +159,8 @@ context(#span{trace_id=TraceId,
                    -> maybe(span()) | {error, invalid_attribute}.
 put_attribute(_Key, _Value, undefined) ->
     undefined;
-put_attribute(Key, Value, Span=#span{attributes=Attributes})
-  when is_binary(Key)
-     , (is_binary(Value) orelse is_integer(Value) orelse is_boolean(Value)) ->
-    Span#span{attributes=maps:put(Key, Value, Attributes)};
-put_attribute(_Key, _Value, _Span) ->
-    {error, invalid_attribute}.
+put_attribute(Key, Value, Span=#span{attributes=Attributes}) ->
+    Span#span{attributes=maps:put(Key, Value, Attributes)}.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/test/opencensus_SUITE.erl
+++ b/test/opencensus_SUITE.erl
@@ -79,10 +79,6 @@ attributes_test(_Config) ->
     ChildSpan3 = opencensus:put_attribute(<<"attr-2">>, 123, ChildSpan2),
     ChildSpan4 = opencensus:put_attribute(<<"attr-3">>, true, ChildSpan3),
 
-    %% attribute keys must be binary strings and values must be binary strings, integers or booleans
-    ?assertEqual({error, invalid_attribute}, opencensus:put_attribute('attr-6', <<"value-6">>, ChildSpan4)),
-    ?assertEqual({error, invalid_attribute}, opencensus:put_attribute(<<"attr-7">>, 1.0, ChildSpan4)),
-
     ChildSpan5 = opencensus:finish_span(ChildSpan4),
     ?assert(ChildSpan5#span.end_time > ChildSpan1#span.start_time),
     ?assertNot(maps:is_key(<<"attr-0">>, ChildSpan5#span.attributes)),


### PR DESCRIPTION
We found that we use functions as attribute values to defer computation (e.g. filtering/sampling). This leaves reportes/context managers responsible for properly encoding stuff (in our case - just calling a fun). 