### PR TITLE
Don't lose trace `enabled` flag while using `opencensus:context`

### DIFF
--- a/src/ocp.erl
+++ b/src/ocp.erl
@@ -105,7 +105,12 @@ finish_span() ->
 -spec context() -> opencensus:maybe(opencensus:span()).
 context() ->
     Span = get(?KEY),
-    opencensus:context(Span).
+    Enabled = case get(?CONTEXT) of
+      #trace_context{} = Context -> Context#trace_context.enabled;
+      _ -> false
+    end,
+
+    opencensus:context(Span, Enabled).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/opencensus.erl
+++ b/src/opencensus.erl
@@ -26,6 +26,7 @@
          finish_span/1,
 
          context/1,
+         context/2,
 
          put_attribute/3,
          put_attributes/2,
@@ -147,7 +148,16 @@ context(undefined) ->
 context(#span{trace_id=TraceId,
               span_id=SpanId}) ->
     #trace_context{trace_id=TraceId,
-                   span_id=SpanId}.
+                   span_id=SpanId,
+                   enabled=true}.
+context(undefined, _) ->
+  undefined;
+context(#span{trace_id=TraceId,
+              span_id=SpanId}, Enabled) ->
+    #trace_context{trace_id=TraceId,
+                   span_id=SpanId,
+                   enabled=Enabled}.
+
 
 %%--------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
For example, when you send sampled context to another service where it's restored.