### PR TITLE
ctx encode/decode changes and add ocp:with_child_span that takes attributes

### DIFF
--- a/src/ocp.erl
+++ b/src/ocp.erl
@@ -70,15 +70,21 @@ with_child_span(Name) ->
 
 %%--------------------------------------------------------------------
 %% @doc
+%% Starts a new span with attributes as a child of the current span
+%% and replaces it.
+%% @end
+%%--------------------------------------------------------------------
+-spec with_child_span(unicode:unicode_binary(), opencensus:attributes()) -> opencensus:maybe(opencensus:span_ctx()).
+with_child_span(Name, Attributes) ->
+    with_span(oc_trace:start_span(Name, get(?SPAN_CTX), Attributes)).
+
+%%--------------------------------------------------------------------
+%% @doc
 %% Starts a new span as a child of the current span and uses it as the
 %% current span while running the function `Fun`, finishing the span
 %% and resetting the current span context after the function finishes.
 %% @end
 %%--------------------------------------------------------------------
--spec with_child_span(unicode:unicode_binary(), fun()) -> maybe(opencensus:span_ctx()).
-with_child_span(Name, Fun) ->
-    with_child_span(Name, #{}, Fun).
-
 -spec with_child_span(unicode:unicode_binary(), opencensus:attributes(), fun()) -> maybe(opencensus:span_ctx()).
 with_child_span(Name, Attributes, Fun) ->
     CurrentSpan = get(?SPAN_CTX),

--- a/test/ocp_SUITE.erl
+++ b/test/ocp_SUITE.erl
@@ -39,16 +39,17 @@ end_per_testcase(_, _Config) ->
 with_span_tests(_Config) ->
     SpanName1 = <<"span-1">>,
     SpanName2 = <<"span-2">>,
-    ocp:with_child_span(SpanName1,
+    ocp:with_child_span(SpanName1, #{},
                         fun() ->
                           SpanCtx1 = ocp:current_span(),
                           TraceId = SpanCtx1#span_ctx.trace_id,
                           SpanId1 = SpanCtx1#span_ctx.span_id,
-                          ocp:with_child_span(SpanName2, fun() ->
-                                                           ?assertMatch(#span_ctx{span_id=SpanId2,
-                                                                                  trace_id=TraceId}
-                                                                        when SpanId2 =/= SpanId1, ocp:current_span())
-                                                         end)
+                          ocp:with_child_span(SpanName2, #{},
+                                              fun() ->
+                                                      ?assertMatch(#span_ctx{span_id=SpanId2,
+                                                                             trace_id=TraceId}
+                                                                   when SpanId2 =/= SpanId1, ocp:current_span())
+                                              end)
                         end),
     ?assertMatch(undefined, ocp:current_span()),
     ok.


### PR DESCRIPTION
The old interface for encode/decode didn't work well in actual usage. I've changed it to return undefined when not successful. This makes use when instrumenting servers like Elli have a better flow.