### PR TITLE
Provide facility for encoding/decoding tags as http header

### DIFF
--- a/src/oc_span_ctx_header.erl
+++ b/src/oc_span_ctx_header.erl
@@ -46,7 +46,7 @@ encode(#span_ctx{trace_id=TraceId,
     EncodedSpanId = io_lib:format("~16.16.0b", [SpanId]),
     [?VERSION, "-", EncodedTraceId, "-", EncodedSpanId, "-", Options].
 
--spec decode(iolist() | binary()) -> maybe(opencensus:span_ctx()).
+-spec decode(iodata()) -> maybe(opencensus:span_ctx()).
 decode(TraceContext) when is_list(TraceContext) ->
     decode(list_to_binary(TraceContext));
 decode(<<?VERSION, "-", TraceId:32/binary, "-", SpanId:16/binary, _/binary>>) when TraceId =:= ?ZERO_TRACEID

--- a/src/oc_tag_ctx_header.erl
+++ b/src/oc_tag_ctx_header.erl
@@ -1,0 +1,49 @@
+%%%-------------------------------------------------------------------------
+%% Copyright 2018, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Functions to support sending tags over http as an http header
+%% @end
+%%%-------------------------------------------------------------------------
+-module(oc_tag_ctx_header).
+
+-export([field_name/0,
+         encode/1,
+         decode/1]).
+
+-include("opencensus.hrl").
+
+field_name() ->
+    <<"Trace-State">>.
+
+-spec encode(oc_tags:tags()) -> maybe(iodata()).
+encode(Tags) when map_size(Tags) =:= 0 ->
+    <<"0">>;
+encode(Tags) ->
+    {ok, IOList} = oc_tag_ctx_binary:encode(Tags),
+    base64:encode_to_string(iolist_to_binary(IOList)).
+
+-spec decode(iodata()) -> maybe(oc_tags:tags()).
+decode("0") ->
+    #{};
+decode(<<"0">>) ->
+    #{};
+decode(Thing) ->
+    try base64:decode(iolist_to_binary(Thing)) of
+        Data ->
+            {ok, Tags} = oc_tag_ctx_binary:decode(Data),
+            Tags
+    catch
+        _:_ ->
+            undefined
+    end.

--- a/src/oc_tags.erl
+++ b/src/oc_tags.erl
@@ -33,8 +33,8 @@
 
 -include("opencensus.hrl").
 
--type key()   :: atom() | unicode:latin1_charlist().
--type value() :: unicode:latin1_charlist().
+-type key()   :: atom() | binary() | unicode:latin1_charlist().
+-type value() :: binary() | unicode:latin1_charlist().
 -type tags()  :: #{key() => value()}.
 
 -spec new() -> tags().
@@ -75,11 +75,15 @@ put(Key, Value, Tags) ->
 
 verify_key(Key) when is_atom(Key) ->
   verify_key(atom_to_list(Key));
+verify_key(Key) when is_binary(Key) ->
+  verify_key(binary_to_list(Key));
 verify_key(Key) ->
     KeyLength = erlang:length(Key),
     KeyLength > 0 andalso KeyLength < 256 andalso
         io_lib:printable_latin1_list(Key).
 
+verify_value(Value) when is_binary(Value) ->
+  verify_value(binary_to_list(Value));
 verify_value(Value) ->
     erlang:length(Value) < 256 andalso io_lib:printable_latin1_list(Value).
 

--- a/test/oc_tags_SUITE.erl
+++ b/test/oc_tags_SUITE.erl
@@ -10,7 +10,13 @@
 -include_lib("common_test/include/ct.hrl").
 
 all() ->
-    [encode_decode, invalid_tags, basic, ctx].
+    [
+     basic,
+     ctx,
+     encode_decode,
+     encode_decode_headers,
+     invalid_tags
+    ].
 
 encode_decode(_Config) ->
     Empty = #{},
@@ -23,6 +29,20 @@ encode_decode(_Config) ->
     {ok, IOList} = oc_tag_ctx_binary:encode(T),
     EncodedT = iolist_to_binary(IOList),
     ?assertMatch({ok, T}, oc_tag_ctx_binary:decode(EncodedT)),
+    ok.
+
+encode_decode_headers(_Config) ->
+    Empty = #{},
+    EmptyHeader = oc_tag_ctx_header:encode(Empty),
+    ?assertMatch(<<"0">>, EmptyHeader),
+    ?assertMatch(Empty, oc_tag_ctx_header:decode(EmptyHeader)),
+
+    T = #{'key-1' => "value-1",
+          "key-2" => "value-2"},
+    Header = oc_tag_ctx_header:encode(T),
+    ?assertMatch("AAAFa2V5LTEHdmFsdWUtMQAFa2V5LTIHdmFsdWUtMg==", Header),
+    ?assertMatch(#{"key-1" := "value-1",
+                   "key-2" := "value-2"}, oc_tag_ctx_header:decode(Header)),
     ok.
 
 invalid_tags(_Config) ->
@@ -38,15 +58,15 @@ invalid_tags(_Config) ->
     ok.
 
 basic(_Config) ->
-    Tags = oc_tags:new(#{"key-1" => "value-1",
-                         "key-2" => "value-2"}),
-    {ok, Tags1} = oc_tags:put("key-3", "value-3", Tags),
+    Tags = oc_tags:new(#{'key-1' => "value-1",
+                         <<"key-2">> => "value-2"}),
+    {ok, Tags1} = oc_tags:put("key-3", <<"value-3">>, Tags),
     {ok, Tags2} = oc_tags:put("key-4", "value-4", Tags1),
 
 
-    ?assertMatch(#{"key-1" := "value-1",
-                   "key-2" := "value-2",
-                   "key-3" := "value-3",
+    ?assertMatch(#{'key-1' := "value-1",
+                   <<"key-2">> := "value-2",
+                   "key-3" := <<"value-3">>,
                    "key-4" := "value-4"}, oc_tags:to_map(Tags2)).
 
 ctx(_Config) ->


### PR DESCRIPTION
Also keys/values type requirements (still doing validation)

This standardizes tags propagation via HTTP on Opencensus side, implementation can be
changed later when TracingContext is more stable.