### PR TITLE
Reimplement views

### DIFF
--- a/doc/oc_stat_aggregation.md
+++ b/doc/oc_stat_aggregation.md
@@ -2,5 +2,5 @@
 
 # Module oc_stat_aggregation #
 
-__This module defines the `oc_stat_aggregation` behaviour.__<br /> Required callback functions: `init/3`, `type/0`, `add_sample/4`, `export/2`.
+__This module defines the `oc_stat_aggregation` behaviour.__<br /> Required callback functions: `init/3`, `type/0`, `add_sample/4`, `export/2`, `clear_rows/2`.
 

--- a/doc/oc_stat_aggregation_count.md
+++ b/doc/oc_stat_aggregation_count.md
@@ -9,7 +9,7 @@
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_sample-4">add_sample/4</a></td><td></td></tr><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-3">init/3</a></td><td></td></tr><tr><td valign="top"><a href="#type-0">type/0</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_sample-4">add_sample/4</a></td><td></td></tr><tr><td valign="top"><a href="#clear_rows-2">clear_rows/2</a></td><td></td></tr><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-3">init/3</a></td><td></td></tr><tr><td valign="top"><a href="#type-0">type/0</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -24,6 +24,12 @@
 add_sample(Name::<a href="oc_stat_view.md#type-name">oc_stat_view:name()</a>, Tags::<a href="oc_tags.md#type-tags">oc_tags:tags()</a>, Value::number(), Options::any()) -&gt; ok
 </code></pre>
 <br />
+
+<a name="clear_rows-2"></a>
+
+### clear_rows/2 ###
+
+`clear_rows(Name, Options) -> any()`
 
 <a name="export-2"></a>
 

--- a/doc/oc_stat_aggregation_distribution.md
+++ b/doc/oc_stat_aggregation_distribution.md
@@ -9,7 +9,7 @@
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_sample-4">add_sample/4</a></td><td></td></tr><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-3">init/3</a></td><td></td></tr><tr><td valign="top"><a href="#type-0">type/0</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_sample-4">add_sample/4</a></td><td></td></tr><tr><td valign="top"><a href="#clear_rows-2">clear_rows/2</a></td><td></td></tr><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-3">init/3</a></td><td></td></tr><tr><td valign="top"><a href="#type-0">type/0</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -24,6 +24,12 @@
 add_sample(Name::<a href="oc_stat_view.md#type-name">oc_stat_view:name()</a>, Tags::<a href="oc_tags.md#type-tags">oc_tags:tags()</a>, Value::number(), Buckets::any()) -&gt; ok
 </code></pre>
 <br />
+
+<a name="clear_rows-2"></a>
+
+### clear_rows/2 ###
+
+`clear_rows(Name, Options) -> any()`
 
 <a name="export-2"></a>
 

--- a/doc/oc_stat_aggregation_latest.md
+++ b/doc/oc_stat_aggregation_latest.md
@@ -9,7 +9,7 @@
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_sample-4">add_sample/4</a></td><td></td></tr><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-3">init/3</a></td><td></td></tr><tr><td valign="top"><a href="#type-0">type/0</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_sample-4">add_sample/4</a></td><td></td></tr><tr><td valign="top"><a href="#clear_rows-2">clear_rows/2</a></td><td></td></tr><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-3">init/3</a></td><td></td></tr><tr><td valign="top"><a href="#type-0">type/0</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -24,6 +24,12 @@
 add_sample(Name::<a href="oc_stat_view.md#type-name">oc_stat_view:name()</a>, Tags::<a href="oc_tags.md#type-tags">oc_tags:tags()</a>, Value::number(), Options::any()) -&gt; ok
 </code></pre>
 <br />
+
+<a name="clear_rows-2"></a>
+
+### clear_rows/2 ###
+
+`clear_rows(Name, Options) -> any()`
 
 <a name="export-2"></a>
 

--- a/doc/oc_stat_aggregation_sum.md
+++ b/doc/oc_stat_aggregation_sum.md
@@ -9,7 +9,7 @@
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_sample-4">add_sample/4</a></td><td></td></tr><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-3">init/3</a></td><td></td></tr><tr><td valign="top"><a href="#type-0">type/0</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_sample-4">add_sample/4</a></td><td></td></tr><tr><td valign="top"><a href="#clear_rows-2">clear_rows/2</a></td><td></td></tr><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-3">init/3</a></td><td></td></tr><tr><td valign="top"><a href="#type-0">type/0</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -24,6 +24,12 @@
 add_sample(Name::<a href="oc_stat_view.md#type-name">oc_stat_view:name()</a>, Tags::<a href="oc_tags.md#type-tags">oc_tags:tags()</a>, Value::number(), Options::any()) -&gt; ok
 </code></pre>
 <br />
+
+<a name="clear_rows-2"></a>
+
+### clear_rows/2 ###
+
+`clear_rows(Name, Options) -> any()`
 
 <a name="export-2"></a>
 

--- a/doc/oc_stat_view.md
+++ b/doc/oc_stat_view.md
@@ -32,6 +32,26 @@ name() = atom() | binary() | string()
 
 
 
+### <a name="type-v_s">v_s()</a> ###
+
+
+<pre><code>
+v_s() = #v_s{name = <a href="#type-name">name()</a>, tags = [<a href="oc_tags.md#type-key">oc_tags:key()</a>], aggregation = <a href="#type-aggregation">aggregation()</a>, aggregation_options = <a href="#type-aggregation_options">aggregation_options()</a>}
+</code></pre>
+
+
+
+
+### <a name="type-view">view()</a> ###
+
+
+<pre><code>
+view() = #view{name = <a href="#type-name">name()</a> | _, measure = <a href="#type-measure_name">measure_name()</a> | _, subscribed = boolean(), description = <a href="#type-description">description()</a> | _, ctags = <a href="oc_tags.md#type-tags">oc_tags:tags()</a> | _, tags = [<a href="oc_tags.md#type-key">oc_tags:key()</a>] | _, aggregation = <a href="#type-aggregation">aggregation()</a> | _, aggregation_options = <a href="#type-aggregation_options">aggregation_options()</a> | _}
+</code></pre>
+
+
+
+
 ### <a name="type-view_data">view_data()</a> ###
 
 
@@ -44,9 +64,7 @@ view_data() = #{name =&gt; <a href="#type-name">name()</a>, description =&gt; <a
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#__init_backend__-0">'__init_backend__'/0</a></td><td></td></tr><tr><td valign="top"><a href="#add_sample-3">add_sample/3</a></td><td></td></tr><tr><td valign="top"><a href="#batch_subscribe-1">batch_subscribe/1</a></td><td>
-Subscribe many <code>Views</code> at once.</td></tr><tr><td valign="top"><a href="#deregister-1">deregister/1</a></td><td></td></tr><tr><td valign="top"><a href="#export-1">export/1</a></td><td></td></tr><tr><td valign="top"><a href="#measure_views-1">measure_views/1</a></td><td></td></tr><tr><td valign="top"><a href="#register-5">register/5</a></td><td></td></tr><tr><td valign="top"><a href="#registered-1">registered/1</a></td><td>
-Checks whether a view <code>Name</code> is registered.</td></tr><tr><td valign="top"><a href="#subscribe-1">subscribe/1</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-5">subscribe/5</a></td><td></td></tr><tr><td valign="top"><a href="#subscribed-0">subscribed/0</a></td><td></td></tr><tr><td valign="top"><a href="#subscribed-1">subscribed/1</a></td><td></td></tr><tr><td valign="top"><a href="#unsubscribe-1">unsubscribe/1</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#__init_backend__-0">'__init_backend__'/0</a></td><td></td></tr><tr><td valign="top"><a href="#add_sample-3">add_sample/3</a></td><td></td></tr><tr><td valign="top"><a href="#all_subscribed-0">all_subscribed/0</a></td><td></td></tr><tr><td valign="top"><a href="#code_change-3">code_change/3</a></td><td></td></tr><tr><td valign="top"><a href="#deregister-1">deregister/1</a></td><td></td></tr><tr><td valign="top"><a href="#export-1">export/1</a></td><td></td></tr><tr><td valign="top"><a href="#handle_call-3">handle_call/3</a></td><td></td></tr><tr><td valign="top"><a href="#handle_cast-2">handle_cast/2</a></td><td></td></tr><tr><td valign="top"><a href="#handle_info-2">handle_info/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr><tr><td valign="top"><a href="#is_registered-1">is_registered/1</a></td><td></td></tr><tr><td valign="top"><a href="#is_subscribed-1">is_subscribed/1</a></td><td></td></tr><tr><td valign="top"><a href="#measure_views-1">measure_views/1</a></td><td></td></tr><tr><td valign="top"><a href="#new-1">new/1</a></td><td></td></tr><tr><td valign="top"><a href="#new-5">new/5</a></td><td></td></tr><tr><td valign="top"><a href="#preload-1">preload/1</a></td><td></td></tr><tr><td valign="top"><a href="#register-1">register/1</a></td><td></td></tr><tr><td valign="top"><a href="#register-5">register/5</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-1">subscribe/1</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-5">subscribe/5</a></td><td></td></tr><tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr><tr><td valign="top"><a href="#unsubscribe-1">unsubscribe/1</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -63,25 +81,29 @@ Checks whether a view <code>Name</code> is registered.</td></tr><tr><td valign="
 
 ### add_sample/3 ###
 
-`add_sample(X1, ContextTags, Value) -> any()`
-
-<a name="batch_subscribe-1"></a>
-
-### batch_subscribe/1 ###
-
 <pre><code>
-batch_subscribe(Views::[<a href="#type-name">name()</a> | map()]) -&gt; ok
+add_sample(ViewSub::<a href="#type-v_s">v_s()</a>, ContextTags::<a href="oc_tags.md#type-tags">oc_tags:tags()</a>, Value::number()) -&gt; ok
 </code></pre>
 <br />
 
-Subscribe many `Views` at once.
+<a name="all_subscribed-0"></a>
+
+### all_subscribed/0 ###
+
+`all_subscribed() -> any()`
+
+<a name="code_change-3"></a>
+
+### code_change/3 ###
+
+`code_change(OldVsn, State, Extra) -> any()`
 
 <a name="deregister-1"></a>
 
 ### deregister/1 ###
 
 <pre><code>
-deregister(Name::<a href="#type-name">name()</a>) -&gt; ok
+deregister(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</a>) -&gt; ok
 </code></pre>
 <br />
 
@@ -90,7 +112,49 @@ deregister(Name::<a href="#type-name">name()</a>) -&gt; ok
 ### export/1 ###
 
 <pre><code>
-export(X1::tuple()) -&gt; <a href="#type-view_data">view_data()</a>
+export(View::<a href="#type-view">view()</a>) -&gt; <a href="#type-view_data">view_data()</a>
+</code></pre>
+<br />
+
+<a name="handle_call-3"></a>
+
+### handle_call/3 ###
+
+`handle_call(X1, From, State) -> any()`
+
+<a name="handle_cast-2"></a>
+
+### handle_cast/2 ###
+
+`handle_cast(X1, State) -> any()`
+
+<a name="handle_info-2"></a>
+
+### handle_info/2 ###
+
+`handle_info(X1, State) -> any()`
+
+<a name="init-1"></a>
+
+### init/1 ###
+
+`init(Args) -> any()`
+
+<a name="is_registered-1"></a>
+
+### is_registered/1 ###
+
+<pre><code>
+is_registered(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</a>) -&gt; boolean()
+</code></pre>
+<br />
+
+<a name="is_subscribed-1"></a>
+
+### is_subscribed/1 ###
+
+<pre><code>
+is_subscribed(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</a>) -&gt; boolean()
 </code></pre>
 <br />
 
@@ -100,32 +164,51 @@ export(X1::tuple()) -&gt; <a href="#type-view_data">view_data()</a>
 
 `measure_views(Measure) -> any()`
 
+<a name="new-1"></a>
+
+### new/1 ###
+
+`new(Map) -> any()`
+
+<a name="new-5"></a>
+
+### new/5 ###
+
+`new(Name, Measure, Description, Tags, Aggregation) -> any()`
+
+<a name="preload-1"></a>
+
+### preload/1 ###
+
+`preload(List) -> any()`
+
+<a name="register-1"></a>
+
+### register/1 ###
+
+<pre><code>
+register(View::<a href="#type-view">view()</a>) -&gt; {ok, #view{name = <a href="#type-name">name()</a> | _, measure = <a href="#type-measure_name">measure_name()</a> | _, subscribed = boolean(), description = <a href="#type-description">description()</a> | _, ctags = <a href="oc_tags.md#type-tags">oc_tags:tags()</a> | _, tags = [<a href="oc_tags.md#type-key">oc_tags:key()</a>] | _, aggregation = <a href="#type-aggregation">aggregation()</a> | _, aggregation_options = <a href="#type-aggregation_options">aggregation_options()</a> | _}} | {error, any()}
+</code></pre>
+<br />
+
 <a name="register-5"></a>
 
 ### register/5 ###
 
-<pre><code>
-register(Name::<a href="#type-name">name()</a>, Description::<a href="#type-description">description()</a>, Tags::<a href="oc_tags.md#type-tags">oc_tags:tags()</a>, Measure::<a href="#type-measure_name">measure_name()</a>, Aggregation::<a href="#type-aggregation">aggregation()</a>) -&gt; ok
-</code></pre>
-<br />
+`register(Name, Measure, Description, Tags, Aggregation) -> any()`
 
-<a name="registered-1"></a>
+<a name="start_link-0"></a>
 
-### registered/1 ###
+### start_link/0 ###
 
-<pre><code>
-registered(Name::<a href="#type-name">name()</a>) -&gt; boolean()
-</code></pre>
-<br />
-
-Checks whether a view `Name` is registered.
+`start_link() -> any()`
 
 <a name="subscribe-1"></a>
 
 ### subscribe/1 ###
 
 <pre><code>
-subscribe(Name::map() | <a href="#type-name">name()</a>) -&gt; ok
+subscribe(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</a>) -&gt; {ok, #view{name = <a href="#type-name">name()</a> | _, measure = <a href="#type-measure_name">measure_name()</a> | _, subscribed = boolean(), description = <a href="#type-description">description()</a> | _, ctags = <a href="oc_tags.md#type-tags">oc_tags:tags()</a> | _, tags = [<a href="oc_tags.md#type-key">oc_tags:key()</a>] | _, aggregation = <a href="#type-aggregation">aggregation()</a> | _, aggregation_options = <a href="#type-aggregation_options">aggregation_options()</a> | _}} | {error, any()}
 </code></pre>
 <br />
 
@@ -133,29 +216,20 @@ subscribe(Name::map() | <a href="#type-name">name()</a>) -&gt; ok
 
 ### subscribe/5 ###
 
-<pre><code>
-subscribe(Name::<a href="#type-name">name()</a>, Description::<a href="#type-description">description()</a>, Tags::<a href="oc_tags.md#type-tags">oc_tags:tags()</a>, Measure::<a href="#type-measure_name">measure_name()</a>, Aggregation::<a href="#type-aggregation">aggregation()</a>) -&gt; ok
-</code></pre>
-<br />
+`subscribe(Name, Measure, Description, Tags, Aggregation) -> any()`
 
-<a name="subscribed-0"></a>
+<a name="terminate-2"></a>
 
-### subscribed/0 ###
+### terminate/2 ###
 
-`subscribed() -> any()`
-
-<a name="subscribed-1"></a>
-
-### subscribed/1 ###
-
-`subscribed(X1) -> any()`
+`terminate(X1, X2) -> any()`
 
 <a name="unsubscribe-1"></a>
 
 ### unsubscribe/1 ###
 
 <pre><code>
-unsubscribe(Name::<a href="#type-name">name()</a>) -&gt; ok
+unsubscribe(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</a>) -&gt; ok
 </code></pre>
 <br />
 

--- a/doc/oc_stat_view.md
+++ b/doc/oc_stat_view.md
@@ -1,10 +1,18 @@
 
 
 # Module oc_stat_view #
+* [Description](#description)
 * [Data Types](#types)
 * [Function Index](#index)
 * [Function Details](#functions)
 
+View allows users to aggregate the recorded Measurements.
+
+<a name="description"></a>
+
+## Description ##
+Views need to be passed to the subscribe function to be before data will be
+collected and sent to exporters.
 <a name="types"></a>
 
 ## Data Types ##
@@ -32,16 +40,6 @@ name() = atom() | binary() | string()
 
 
 
-### <a name="type-v_s">v_s()</a> ###
-
-
-<pre><code>
-v_s() = #v_s{name = <a href="#type-name">name()</a>, tags = [<a href="oc_tags.md#type-key">oc_tags:key()</a>], aggregation = <a href="#type-aggregation">aggregation()</a>, aggregation_options = <a href="#type-aggregation_options">aggregation_options()</a>}
-</code></pre>
-
-
-
-
 ### <a name="type-view">view()</a> ###
 
 
@@ -64,7 +62,19 @@ view_data() = #{name =&gt; <a href="#type-name">name()</a>, description =&gt; <a
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#__init_backend__-0">'__init_backend__'/0</a></td><td></td></tr><tr><td valign="top"><a href="#add_sample-3">add_sample/3</a></td><td></td></tr><tr><td valign="top"><a href="#all_subscribed-0">all_subscribed/0</a></td><td></td></tr><tr><td valign="top"><a href="#code_change-3">code_change/3</a></td><td></td></tr><tr><td valign="top"><a href="#deregister-1">deregister/1</a></td><td></td></tr><tr><td valign="top"><a href="#export-1">export/1</a></td><td></td></tr><tr><td valign="top"><a href="#handle_call-3">handle_call/3</a></td><td></td></tr><tr><td valign="top"><a href="#handle_cast-2">handle_cast/2</a></td><td></td></tr><tr><td valign="top"><a href="#handle_info-2">handle_info/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr><tr><td valign="top"><a href="#is_registered-1">is_registered/1</a></td><td></td></tr><tr><td valign="top"><a href="#is_subscribed-1">is_subscribed/1</a></td><td></td></tr><tr><td valign="top"><a href="#measure_views-1">measure_views/1</a></td><td></td></tr><tr><td valign="top"><a href="#new-1">new/1</a></td><td></td></tr><tr><td valign="top"><a href="#new-5">new/5</a></td><td></td></tr><tr><td valign="top"><a href="#preload-1">preload/1</a></td><td></td></tr><tr><td valign="top"><a href="#register-1">register/1</a></td><td></td></tr><tr><td valign="top"><a href="#register-5">register/5</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-1">subscribe/1</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-5">subscribe/5</a></td><td></td></tr><tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr><tr><td valign="top"><a href="#unsubscribe-1">unsubscribe/1</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#__init_backend__-0">'__init_backend__'/0</a></td><td></td></tr><tr><td valign="top"><a href="#code_change-3">code_change/3</a></td><td></td></tr><tr><td valign="top"><a href="#deregister-1">deregister/1</a></td><td>
+Deregisters the view.</td></tr><tr><td valign="top"><a href="#export-1">export/1</a></td><td>
+Returns a snapshot of the View's data.</td></tr><tr><td valign="top"><a href="#handle_call-3">handle_call/3</a></td><td></td></tr><tr><td valign="top"><a href="#handle_cast-2">handle_cast/2</a></td><td></td></tr><tr><td valign="top"><a href="#handle_info-2">handle_info/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr><tr><td valign="top"><a href="#is_registered-1">is_registered/1</a></td><td>
+Returns true if the view is registered.</td></tr><tr><td valign="top"><a href="#is_subscribed-1">is_subscribed/1</a></td><td>
+Returns true if the view is exporting data by subscription.</td></tr><tr><td valign="top"><a href="#new-1">new/1</a></td><td>
+Creates a View from a map.</td></tr><tr><td valign="top"><a href="#new-5">new/5</a></td><td>
+Creates a View.</td></tr><tr><td valign="top"><a href="#preload-1">preload/1</a></td><td>
+Loads and subscribes views from the <code>List</code> in one shot.</td></tr><tr><td valign="top"><a href="#register-1">register/1</a></td><td>
+Registers the view.</td></tr><tr><td valign="top"><a href="#register-5">register/5</a></td><td>
+Registers the view created from arguments.</td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-1">subscribe/1</a></td><td>
+Subscribe the View, When subscribed, a view can aggregate measure data and export it.</td></tr><tr><td valign="top"><a href="#subscribe-5">subscribe/5</a></td><td>
+A shortcut.</td></tr><tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr><tr><td valign="top"><a href="#unsubscribe-1">unsubscribe/1</a></td><td>
+Unsubscribes the View.</td></tr></table>
 
 
 <a name="functions"></a>
@@ -76,21 +86,6 @@ view_data() = #{name =&gt; <a href="#type-name">name()</a>, description =&gt; <a
 ### '__init_backend__'/0 ###
 
 `__init_backend__() -> any()`
-
-<a name="add_sample-3"></a>
-
-### add_sample/3 ###
-
-<pre><code>
-add_sample(ViewSub::<a href="#type-v_s">v_s()</a>, ContextTags::<a href="oc_tags.md#type-tags">oc_tags:tags()</a>, Value::number()) -&gt; ok
-</code></pre>
-<br />
-
-<a name="all_subscribed-0"></a>
-
-### all_subscribed/0 ###
-
-`all_subscribed() -> any()`
 
 <a name="code_change-3"></a>
 
@@ -107,6 +102,9 @@ deregister(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</
 </code></pre>
 <br />
 
+Deregisters the view. If subscribed, unsubscribes and therefore
+existing aggregation data cleared.
+
 <a name="export-1"></a>
 
 ### export/1 ###
@@ -115,6 +113,8 @@ deregister(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</
 export(View::<a href="#type-view">view()</a>) -&gt; <a href="#type-view_data">view_data()</a>
 </code></pre>
 <br />
+
+Returns a snapshot of the View's data.
 
 <a name="handle_call-3"></a>
 
@@ -149,6 +149,8 @@ is_registered(View::<a href="#type-name">name()</a> | <a href="#type-view">view(
 </code></pre>
 <br />
 
+Returns true if the view is registered.
+
 <a name="is_subscribed-1"></a>
 
 ### is_subscribed/1 ###
@@ -158,11 +160,7 @@ is_subscribed(View::<a href="#type-name">name()</a> | <a href="#type-view">view(
 </code></pre>
 <br />
 
-<a name="measure_views-1"></a>
-
-### measure_views/1 ###
-
-`measure_views(Measure) -> any()`
+Returns true if the view is exporting data by subscription.
 
 <a name="new-1"></a>
 
@@ -170,11 +168,16 @@ is_subscribed(View::<a href="#type-name">name()</a> | <a href="#type-view">view(
 
 `new(Map) -> any()`
 
+Creates a View from a map.
+
 <a name="new-5"></a>
 
 ### new/5 ###
 
 `new(Name, Measure, Description, Tags, Aggregation) -> any()`
+
+Creates a View. This view needs to be registered and subscribed to a measure
+in order to start aggregating data.
 
 <a name="preload-1"></a>
 
@@ -182,20 +185,27 @@ is_subscribed(View::<a href="#type-name">name()</a> | <a href="#type-view">view(
 
 `preload(List) -> any()`
 
+Loads and subscribes views from the `List` in one shot.
+Usually used for loading views from configuration on app start.
+
 <a name="register-1"></a>
 
 ### register/1 ###
 
 <pre><code>
-register(View::<a href="#type-view">view()</a>) -&gt; {ok, #view{name = <a href="#type-name">name()</a> | _, measure = <a href="#type-measure_name">measure_name()</a> | _, subscribed = boolean(), description = <a href="#type-description">description()</a> | _, ctags = <a href="oc_tags.md#type-tags">oc_tags:tags()</a> | _, tags = [<a href="oc_tags.md#type-key">oc_tags:key()</a>] | _, aggregation = <a href="#type-aggregation">aggregation()</a> | _, aggregation_options = <a href="#type-aggregation_options">aggregation_options()</a> | _}} | {error, any()}
+register(View::<a href="#type-view">view()</a>) -&gt; {ok, <a href="#type-view">view()</a>} | {error, any()}
 </code></pre>
 <br />
+
+Registers the view. Aggregation initialized with AggregationOptions.
 
 <a name="register-5"></a>
 
 ### register/5 ###
 
 `register(Name, Measure, Description, Tags, Aggregation) -> any()`
+
+Registers the view created from arguments.
 
 <a name="start_link-0"></a>
 
@@ -208,15 +218,19 @@ register(View::<a href="#type-view">view()</a>) -&gt; {ok, #view{name = <a href=
 ### subscribe/1 ###
 
 <pre><code>
-subscribe(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</a>) -&gt; {ok, #view{name = <a href="#type-name">name()</a> | _, measure = <a href="#type-measure_name">measure_name()</a> | _, subscribed = boolean(), description = <a href="#type-description">description()</a> | _, ctags = <a href="oc_tags.md#type-tags">oc_tags:tags()</a> | _, tags = [<a href="oc_tags.md#type-key">oc_tags:key()</a>] | _, aggregation = <a href="#type-aggregation">aggregation()</a> | _, aggregation_options = <a href="#type-aggregation_options">aggregation_options()</a> | _}} | {error, any()}
+subscribe(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</a>) -&gt; {ok, <a href="#type-view">view()</a>} | {error, any()}
 </code></pre>
 <br />
+
+Subscribe the View, When subscribed, a view can aggregate measure data and export it.
 
 <a name="subscribe-5"></a>
 
 ### subscribe/5 ###
 
 `subscribe(Name, Measure, Description, Tags, Aggregation) -> any()`
+
+A shortcut. Creates, Registers, and Subscribes a view in one call.
 
 <a name="terminate-2"></a>
 
@@ -232,4 +246,7 @@ subscribe(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</a
 unsubscribe(View::<a href="#type-name">name()</a> | <a href="#type-view">view()</a>) -&gt; ok
 </code></pre>
 <br />
+
+Unsubscribes the View. When unsubscribed a view no longer aggregates measure data
+and exports it. Also all existing aggregation data cleared.
 

--- a/include/opencensus.hrl
+++ b/include/opencensus.hrl
@@ -118,5 +118,6 @@
           message :: unicode:unicode_binary()
          }).
 
--type measure_name() :: atom() | binary() | string().
--type aggregation() :: atom().
+-type measure_name()        :: atom() | binary() | string().
+-type aggregation()         :: module().
+-type aggregation_options() :: any().

--- a/src/oc_stat.erl
+++ b/src/oc_stat.erl
@@ -27,9 +27,8 @@
 %% If there are any tags in the context, measurements will be tagged with them.
 -spec record(ctx:t() | oc_tags:tags(), measure_name(), number()) -> ok.
 record(Tags, MeasureName, Value) when is_map(Tags) ->
-    [oc_stat_view:add_sample(View, Tags, Value)
-     || View <- oc_stat_view:measure_views(MeasureName),
-        oc_stat_view:subscribed(View)],
+    [oc_stat_view:add_sample(ViewSub, Tags, Value)
+     || ViewSub <- oc_stat_view:measure_views(MeasureName)],
     ok;
 record(Ctx, MeasureName, Value)->
     Tags = oc_tags:from_ctx(Ctx),
@@ -48,4 +47,4 @@ record(Ctx, Measures) ->
 %% @doc Exports view_data of all subscribed views
 -spec export() -> oc_stat_view:view_data().
 export() ->
-    [oc_stat_view:export(View) || View <- oc_stat_view:subscribed()].
+    [oc_stat_view:export(View) || View <- oc_stat_view:all_subscribed()].

--- a/src/oc_stat_aggregation.erl
+++ b/src/oc_stat_aggregation.erl
@@ -28,3 +28,5 @@
 -callback add_sample(oc_stat_view:name(), oc_tags:tags(), number(), any()) -> ok.
 
 -callback export(oc_stat_view:name(), any()) -> data().
+
+-callback clear_rows(oc_stat_view:name(), any()) -> ok.

--- a/src/oc_stat_aggregation_count.erl
+++ b/src/oc_stat_aggregation_count.erl
@@ -5,7 +5,8 @@
 -export([init/3,
          type/0,
          add_sample/4,
-         export/2]).
+         export/2,
+         clear_rows/2]).
 
 -export_types([value/0]).
 
@@ -36,3 +37,7 @@ export(Name, _Options) ->
                                 counters_simple:value(Name))),
     #{type => type(),
       rows => Rows}.
+
+clear_rows(Name, _Options) ->
+    counters_simple:remove(Name),
+    ok.

--- a/src/oc_stat_aggregation_distribution.erl
+++ b/src/oc_stat_aggregation_distribution.erl
@@ -3,7 +3,8 @@
 -export([init/3,
          type/0,
          add_sample/4,
-         export/2]).
+         export/2,
+         clear_rows/2]).
 
 -behavior(oc_stat_aggregation).
 
@@ -55,3 +56,7 @@ export(Name, Buckets) ->
                       counters_distribution:value(Name))),
     #{type => type(),
       rows => Rows}.
+
+clear_rows(Name, _Options) ->
+    counters_distribution:remove(Name),
+    ok.

--- a/src/oc_stat_aggregation_latest.erl
+++ b/src/oc_stat_aggregation_latest.erl
@@ -3,7 +3,8 @@
 -export([init/3,
          type/0,
          add_sample/4,
-         export/2]).
+         export/2,
+         clear_rows/2]).
 
 -behavior(oc_stat_aggregation).
 
@@ -34,3 +35,7 @@ export(Name, _Options) ->
                                 counters_counter:value(Name))),
     #{type => type(),
       rows => Rows}.
+
+clear_rows(Name, _Options) ->
+    counters_counter:remove(Name),
+    ok.

--- a/src/oc_stat_aggregation_sum.erl
+++ b/src/oc_stat_aggregation_sum.erl
@@ -3,7 +3,8 @@
 -export([init/3,
          type/0,
          add_sample/4,
-         export/2]).
+         export/2,
+         clear_rows/2]).
 
 -behavior(oc_stat_aggregation).
 
@@ -40,3 +41,7 @@ export(Name, _Options) ->
                                 counters_sum:value(Name))),
     #{type => type(),
       rows => Rows}.
+
+clear_rows(Name, _Options) ->
+    counters_sum:remove(Name),
+    ok.

--- a/src/oc_stat_view.erl
+++ b/src/oc_stat_view.erl
@@ -89,7 +89,7 @@ new(Name, Measure, Description, Tags, Aggregation) ->
 register(Name, Measure, Description, Tags, Aggregation) ->
     register(new(Name, Measure, Description, Tags, Aggregation)).
 
--spec register(view()) -> {ok, #view{}} | {error, any()}.
+-spec register(view()) -> {ok, view()} | {error, any()}.
 register(#view{}=View) ->
     gen_server:call(?MODULE, {register, View}).
 
@@ -115,7 +115,7 @@ subscribe(Name, Measure, Description, Tags, Aggregation) ->
     {ok, SView} = subscribe(RView),
     {ok, SView}.
 
--spec subscribe(name() | view()) -> {ok, #view{}} | {error, any()}.
+-spec subscribe(name() | view()) -> {ok, view()} | {error, any()}.
 subscribe(#view{name=Name}) ->
     subscribe(Name);
 subscribe(Name) ->

--- a/src/oc_stat_view.erl
+++ b/src/oc_stat_view.erl
@@ -1,18 +1,30 @@
 -module(oc_stat_view).
 
--export([register/5,
+-export([new/1,
+         new/5,
+         register/5,
+         register/1,
          deregister/1,
-         subscribe/1,
+         is_registered/1,
          subscribe/5,
-         batch_subscribe/1,
-         subscribed/1,
+         subscribe/1,
          unsubscribe/1,
-         registered/1]).
+         is_subscribed/1]).
+
+-export([preload/1]).
 
 -export([measure_views/1,
-         subscribed/0,
          add_sample/3,
+         all_subscribed/0,
          export/1]).
+
+-export([start_link/0,
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         code_change/3,
+         terminate/2]).
 
 -export_types([name/0,
                description/0,
@@ -22,108 +34,304 @@
 
 -include("opencensus.hrl").
 
--define(NAME_POS, 2).
--define(SUBSCRIBED_POS, 3).
+%% enable ets:fun2ms parse transform
+-include_lib("stdlib/include/ms_transform.hrl").
 
--type name() :: atom() | binary() | string().
+-define(VIEWS_TABLE, ?MODULE).
+-define(MEASURES_TABLE, oc_stat_view_subs).
+
+-record(view, {name                :: name() | '_',
+               measure             :: measure_name() | '_',
+               subscribed          :: boolean(),
+               description         :: description() | '_',
+               ctags               :: oc_tags:tags() | '_',
+               tags                :: [oc_tags:key()] | '_',
+               aggregation         :: aggregation() | '_',
+               aggregation_options :: aggregation_options() | '_'}).
+
+-record(v_s, {name                :: name(),
+              tags                :: [oc_tags:key()],
+              aggregation         :: aggregation(),
+              aggregation_options :: aggregation_options()}).
+
+-record(measure, {name :: name(),
+                  subs :: [#v_s{}]}).
+
+-record(state, {}).
+
+-type name()        :: atom() | binary() | string().
 -type description() :: binary() | string().
+-type view_data()   :: #{name        := name(),
+                         description := description(),
+                         ctags       := oc_tags:tags(),
+                         tags        := [oc_tags:key()],
+                         data        := oc_stat_aggregation:data()}.
+-type view()        :: #view{}.
+-type v_s()         :: #v_s{}.
 
--type view_data() :: #{name := name(),
-                       description := description(),
-                       ctags := oc_tags:tags(),
-                       tags := [oc_tags:key()],
-                       data := oc_stat_aggregation:data()}.
+new(Map) when is_map(Map) ->
+    new(maps:get(name, Map), maps:get(measure, Map), maps:get(description, Map),
+        maps:get(tags, Map, []), maps:get(aggregation, Map)).
+
+new(Name, Measure, Description, Tags, Aggregation) ->
+    {CTags, Keys} = normalize_tags(Tags),
+    {AggregationModule, AggregationOptions} = normalize_aggregation(Aggregation),
+    #view{name=Name,
+          measure=Measure,
+          description=Description,
+          subscribed=false,
+          ctags=CTags,
+          tags=Keys,
+          aggregation=AggregationModule,
+          aggregation_options=AggregationOptions}.
 
 
--spec register(name(), description(), oc_tags:tags(),
-               measure_name(), aggregation()) -> ok.
-register(Name, Description, Tags, Measure, Aggregation) ->
-    %% TODO: check Measure exists?
-    register(Name, Description, Tags, Measure, Aggregation, false).
+register(Name, Measure, Description, Tags, Aggregation) ->
+    register(new(Name, Measure, Description, Tags, Aggregation)).
 
--spec deregister(name()) -> ok.
+-spec register(view()) -> {ok, #view{}} | {error, any()}.
+register(#view{}=View) ->
+    gen_server:call(?MODULE, {register, View}).
+
+-spec deregister(name() | view()) -> ok.
+deregister(#view{name=Name}) ->
+    deregister(Name);
 deregister(Name) ->
-    ets:delete(?MODULE, Name),
-    ok.
+    gen_server:call(?MODULE, {deregister, Name}).
 
--spec subscribe(map() | name()) -> ok.
-subscribe(#{name := Name, description := Description, tags := Tags,
-            measure := Measure, aggregation := Aggregation}) ->
-    subscribe(Name, Description, Tags, Measure, Aggregation);
-subscribe(Name) ->
-    ets:update_element(?MODULE, Name, {?SUBSCRIBED_POS, true}),
-    ok.
-
--spec subscribe(name(), description(), oc_tags:tags(),
-                measure_name(), aggregation()) -> ok.
-subscribe(Name, Description, Tags, Measure, Aggregation) ->
-    %% TODO: check Measure exists?
-    register(Name, Description, Tags, Measure, Aggregation, true).
-
-%% @doc
-%% Subscribe many `Views' at once.
-%% @end
--spec batch_subscribe(list(name() | map())) -> ok.
-batch_subscribe(Views) when is_list(Views) ->
-    [ok = subscribe(View) || View <- Views],
-    ok.
-
--spec register(name(), description(), oc_tags:tags(),
-               measure_name(), aggregation(), boolean()) -> ok | no_return().
-register(Name, Description, Tags, Measure, Aggregation, Subscribed) ->
-    NAggregation = normalize_aggregation(Aggregation),
-    NTags = normalize_tags(Tags),
-    case ets:match_object(?MODULE, {Measure, Name, '_', '_', '_', '_'}) of
-        [{Measure, Name, '_', Description, NTags, NAggregation}] ->
-            ets:update_element(?MODULE, Name, {?SUBSCRIBED_POS, Subscribed});
-        [_] ->
-            erlang:error({already_exists, Name});
+-spec is_registered(name() | view()) -> boolean().
+is_registered(#view{name=Name}) ->
+    is_registered(Name);
+is_registered(Name) ->
+    case view_by_name(Name) of
+        unknown ->
+            false;
         _ ->
-            {AggregationModule, AggregationOptions} = NAggregation,
-            {_, Keys} = NTags,
-            %% TODO: transaction?
-            NAggregationOptions = AggregationModule:init(Name, Keys, AggregationOptions),
-            ets:insert(?MODULE, {Measure, Name, Subscribed, Description, NTags,
-                                 {AggregationModule, NAggregationOptions}})
-    end,
-    ok.
+            true
+    end.
 
--spec unsubscribe(name()) -> ok.
+subscribe(Name, Measure, Description, Tags, Aggregation) ->
+    {ok, RView} = register(new(Name, Measure, Description, Tags, Aggregation)),
+    {ok, SView} = subscribe(RView),
+    {ok, SView}.
+
+-spec subscribe(name() | view()) -> {ok, #view{}} | {error, any()}.
+subscribe(#view{name=Name}) ->
+    subscribe(Name);
+subscribe(Name) ->
+    gen_server:call(?MODULE, {subscribe, Name}).
+
+-spec unsubscribe(name() | view()) -> ok.
+unsubscribe(#view{name=Name}) ->
+    unsubscribe(Name);
 unsubscribe(Name) ->
-    ets:update_element(?MODULE, Name, {?SUBSCRIBED_POS, false}),
-    ok.
+    gen_server:call(?MODULE, {unsubscribe, Name}).
 
-%% @doc
-%% Checks whether a view `Name' is registered.
-%% @end
--spec registered(name()) -> boolean().
-registered(Name) ->
-    ets:lookup_element(?MODULE, Name, ?NAME_POS) =/= [].
+-spec is_subscribed(name() | view()) -> boolean().
+is_subscribed(#view{name=Name}) ->
+    is_subscribed(Name);
+is_subscribed(Name) ->
+    case view_by_name(Name) of
+        {ok, #view{subscribed=Subscribed}} ->
+            Subscribed;
+        _ ->
+            false
+    end.
+
+preload(List) ->
+    [begin
+         NV = new(V),
+         case register_(NV) of
+             {ok, RV} ->
+                 subscribe_(RV);
+             {error, Error} ->
+                 %% TODO: should it crash?
+                 error_logger:info_msg("Unable to preload view ~p. Error is ~p", [NV#view.name, Error])
+         end
+     end || V <- List].
 
 measure_views(Measure) ->
-    ets:lookup(?MODULE, Measure).
+    case ets:lookup(?MEASURES_TABLE, Measure) of
+        [#measure{subs=Subs}] ->
+            Subs;
+        _ -> []
+    end.
 
-subscribed({_Measure, _Name, Subscribed, _Description, _Tags, _Aggregation}) ->
-    Subscribed.
+-spec add_sample(v_s(), oc_tags:tags(), number()) -> ok.
+add_sample(ViewSub, ContextTags, Value) ->
+    TagValues = tag_values(ContextTags, ViewSub#v_s.tags),
+    AM = ViewSub#v_s.aggregation,
+    AM:add_sample(ViewSub#v_s.name, TagValues, Value, ViewSub#v_s.aggregation_options),
+    ok.
 
-subscribed() ->
-    ets:match_object(?MODULE, {'_', '_', true, '_', '_', '_'}).
+all_subscribed() ->
+    ets:match_object(?VIEWS_TABLE, #view{subscribed=true, _='_'}).
 
-add_sample({_Measure, Name, _Subscribed, _Description, ViewTags, Aggregation}, ContextTags, Value) ->
-    {_, Keys} = ViewTags,
-    TagValues = tag_values(ContextTags, Keys),
-    {AggregationModule, AggregationOptions} = Aggregation,
-    AggregationModule:add_sample(Name, TagValues, Value, AggregationOptions).
-
--spec export(tuple()) -> view_data().
-export({_Measure, Name, _, Description, ViewTags, Aggregation}) ->
-    {AggregationModule, AggregationOptions} = Aggregation,
-    {CTags, Keys} = ViewTags,
+-spec export(view()) -> view_data().
+export(#view{name=Name, description=Description,
+             ctags=CTags, tags=Keys,
+             aggregation=AggregationModule,
+             aggregation_options=AggregationOptions}) ->
     #{name => Name,
       description => Description,
       ctags => CTags,
       tags => lists:reverse(Keys),
       data => AggregationModule:export(Name, AggregationOptions)}.
+
+%% gen_server implementation
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init(_Args) ->
+    {ok, #state{}}.
+
+handle_call({register, #view{measure=Measure,
+                             name=Name,
+                             description=Description,
+                             ctags=CTags,
+                             tags=Keys,
+                             aggregation=AggregationModule}=View}, _From, State) ->
+    case ets:lookup(?VIEWS_TABLE, Name) of
+        [#view{measure=Measure,
+               name=Name,
+               description=Description,
+               ctags=CTags,
+               tags=Keys,
+               aggregation=AggregationModule}=OldView] ->
+            {reply, {ok, OldView}, State};
+        [_] ->
+            {reply, {error, {already_exists, Name}}, State};
+        _ ->
+            {reply, register_(View), State}
+    end;
+handle_call({deregister, Name}, _From, State) ->
+    case ets:take(?VIEWS_TABLE, Name) of
+        [] -> ok;
+        [View] -> unsubscribe_(View)
+    end,
+    {reply, ok, State};
+handle_call({subscribe, Name}, _From,  State) ->
+    case view_by_name(Name) of
+        {ok, View} ->
+            case subscribe_(View) of
+                ok -> {reply, {ok, View#view{subscribed=true}}, State}
+            end;
+        unknown ->
+            {reply, {error, {unknown_view, Name}}, State}
+    end;
+handle_call({unsubscribe, Name}, _From,  State) ->
+    case view_by_name(Name) of
+        {ok, View} ->
+            case unsubscribe_(View) of
+                ok ->
+                    {reply, {ok, View#view{subscribed=false}}, State}
+            end;
+        unknown ->
+            {reply, {error, {unknown_view, Name}}, State}
+    end;
+handle_call(_, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+handle_info(_, State) ->
+    {noreply, State}.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+terminate(_, _) ->
+    ok.
+
+%% private
+
+register_(#view{measure=Measure,
+                name=Name,
+                description=Description,
+                ctags=CTags,
+                tags=Keys,
+                aggregation=AggregationModule,
+                aggregation_options=AggregationOptions}) ->
+    NAggregationOptions = AggregationModule:init(Name, Keys, AggregationOptions),
+    try
+        NView = #view{measure=Measure,
+                      name=Name,
+                      subscribed=false,
+                      description=Description,
+                      ctags=CTags,
+                      tags=Keys,
+                      aggregation=AggregationModule,
+                      aggregation_options=NAggregationOptions},
+        ets:insert(?VIEWS_TABLE, NView),
+        {ok, NView}
+    catch
+        _:Error -> AggregationModule:clear_rows(Name, NAggregationOptions),
+                   {error, Error}
+    end.
+
+subscribe_(#view{subscribed=true}) ->
+    ok;
+subscribe_(#view{measure=Measure,
+                 name=Name,
+                 tags=Keys,
+                 aggregation=AggregationModule,
+                 aggregation_options=AggregationOptions}=View) ->
+    VS = #v_s{name=Name,
+              tags=Keys,
+              aggregation=AggregationModule,
+              aggregation_options=AggregationOptions},
+    case ets:lookup(?MEASURES_TABLE, Measure) of
+        [] ->
+            ets:insert(?MEASURES_TABLE, #measure{name=Measure,
+                                                 subs=[VS]});
+        [#measure{subs=Subs}=M] ->
+            swap(?MEASURES_TABLE, M, M#measure{subs=[VS | Subs]})
+    end,
+    mark_view_as_subscribed_(View),
+    ok.
+
+unsubscribe_(#view{subscribed=false}) ->
+    ok;
+unsubscribe_(#view{measure=Measure,
+                   name=Name,
+                   tags=Keys,
+                   aggregation=AggregationModule,
+                   aggregation_options=AggregationOptions}=View) ->
+    VS = #v_s{name=Name,
+              tags=Keys,
+              aggregation=AggregationModule,
+              aggregation_options=AggregationOptions},
+    case ets:lookup(?MEASURES_TABLE, Measure) of
+        [] ->
+            ok;
+        [#measure{subs=Subs}=M] ->
+            swap(?MEASURES_TABLE, M, M#measure{subs=lists:delete(VS, Subs)})
+    end,
+    mark_view_as_unsubscribed_(View),
+    #view{aggregation=AggregationModule,
+          aggregation_options=AggregationOptions} = View,
+    AggregationModule:clear_rows(Name, AggregationOptions),
+    ok.
+
+mark_view_as_subscribed_(View) ->
+    swap(?VIEWS_TABLE, View, View#view{subscribed=true}).
+
+mark_view_as_unsubscribed_(View) ->
+    swap(?VIEWS_TABLE, View, View#view{subscribed=false}).
+
+%% privates
+
+swap(Where, What, With) ->
+    ets:select_replace(Where, [{What, [], [{const, With}]}]).
+
+view_by_name(Name) ->
+    case ets:lookup(?VIEWS_TABLE, Name) of
+        [View] ->
+            {ok, View};
+        [] -> unknown
+    end.
 
 normalize_aggregation({Module, Options}) ->
     {Module, Options};
@@ -148,5 +356,6 @@ tag_values(Tags, Keys) ->
                 end, [], Keys).
 
 '__init_backend__'() ->
-    ?MODULE = ets:new(?MODULE, [bag, named_table, public, {read_concurrency, true}]),
+    ?VIEWS_TABLE = ets:new(?VIEWS_TABLE, [set, named_table, public, {keypos, 2}, {read_concurrency, true}]),
+    ?MEASURES_TABLE = ets:new(?MEASURES_TABLE, [set, named_table, public, {keypos, 2}, {read_concurrency, true}]),
     ok.

--- a/src/opencensus_sup.erl
+++ b/src/opencensus_sup.erl
@@ -34,7 +34,7 @@ init([]) ->
 
     ok = oc_stat_view:'__init_backend__'(),
 
-    oc_stat_view:batch_subscribe(oc_stat_config:views()),
+    oc_stat_view:preload(oc_stat_config:views()),
 
     Reporter = #{id => oc_reporter,
                  start => {oc_reporter, start_link, []},
@@ -50,6 +50,13 @@ init([]) ->
                  type => worker,
                  modules => [oc_stat_exporter]},
 
+    ViewServer = #{id => oc_stat_view,
+                   start => {oc_stat_view, start_link, []},
+                   restart => permanent,
+                   shutdown => 1000,
+                   type => worker,
+                   modules => [oc_stat_view]},
+
     TraceServer = #{id => oc_server,
                     start => {oc_server, start_link, []},
                     restart => permanent,
@@ -59,4 +66,4 @@ init([]) ->
 
     {ok, {#{strategy => one_for_one,
             intensity => 1,
-            period => 5}, [Reporter, Exporter, TraceServer]}}.
+            period => 5}, [Reporter, Exporter, ViewServer, TraceServer]}}.

--- a/test/oc_reporters_SUITE.erl
+++ b/test/oc_reporters_SUITE.erl
@@ -151,7 +151,7 @@ zipkin_reporter(_Config) ->
                                       <<"attr_as_function">> := <<"val2">>},
                                 <<"timestamp">> := _,
                                 <<"traceId">> := ParentTraceId}],
-                             jsx:decode(Content, [return_maps]))
+                             lists:sort(jsx:decode(Content, [return_maps])))
 
         after
             6000 -> ct:fail("Zipking reporter doesn't work")

--- a/test/oc_stat_aggregation_pid.erl
+++ b/test/oc_stat_aggregation_pid.erl
@@ -1,0 +1,28 @@
+-module(oc_stat_aggregation_pid).
+
+-export([init/3,
+         type/0,
+         add_sample/4,
+         export/2,
+         clear_rows/2]).
+
+-behavior(oc_stat_aggregation).
+
+init(_Name, _Keys, Pid) ->
+    Pid ! aggregation_init,
+    Pid.
+
+type() ->
+    pid.
+
+-spec add_sample(oc_stat_view:name(), oc_tags:tags(), number(), any()) -> ok.
+add_sample(_Name, _Tags, _Value, _Options) ->
+    ok.
+
+export(_Name, _Options) ->
+    #{type=>type(),
+      rows=>[]}.
+
+clear_rows(_Name, Pid) ->
+    Pid ! aggregation_clear_rows,
+    ok.


### PR DESCRIPTION
I'm using records and separate tables for views/measures. Measures hold subscriptions.
Registration/subscription synchronized in gen_server. Recording/exporting is a direct ETS access.
Also added new `clear_rows/2` callback to aggregations - called when view registration failed or view unsubscribed.

Will add more docs too.