### PR TITLE
increment version script

### DIFF
--- a/bin/increment-version
+++ b/bin/increment-version
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Based on https://github.com/fmahnke/shell-semver
+# The MIT License (MIT)
+# Copyright (c) 2014 Fritz Mahnke
+# Copyright (c) 2016-2019 Ilya Khaprov
+# Increment a version string using Semantic Versioning (SemVer) terminology.
+# Parse command line options.
+
+
+while getopts ":Mmp" Option
+do
+  case $Option in
+    M ) major=true;;
+    m ) minor=true;;
+    p ) patch=true;;
+  esac
+done
+
+shift $(($OPTIND - 1))
+
+STAGED_COUNT=$(git diff --cached --numstat | wc -l)
+UNSTAGED_COUNT=$(git diff --numstat | wc -l)
+
+## TODO check we are on master
+if [ $STAGED_COUNT -ne "0" ]; then
+    echo "you have staged changes. Aborting".
+    exit 1
+fi
+
+if [ $UNSTAGED_COUNT -ne "0" ]; then
+    echo "you have unstaged changes. Aborting".
+    exit 1
+fi
+
+version="$(erl -noshell -s init stop -eval "{ok, [{_,_,Props}]} = file:consult(\"src/opencensus.app.src\"), io:format(\"~s\", [proplists:get_value(vsn, Props)])")"
+
+echo "Old version: ${version}"
+
+# Build array from version string.
+oa=( ${version//./ } )
+a=( ${version//./ } )
+
+# If version string is missing or has the wrong number of members, show usage message.
+
+if [ ${#a[@]} -ne 3 ]
+then
+  echo "usage: $(basename $0) [-Mmp] TAG_MESSAGE(optional)"
+  exit 1
+fi
+
+# Increment version numbers as requested.
+
+if [ ! -z $major ]
+then
+  ((a[0]++))
+  a[1]=0
+  a[2]=0
+fi
+
+if [ ! -z $minor ]
+then
+  ((a[1]++))
+  a[2]=0
+fi
+
+if [ ! -z $patch ]
+then
+  ((a[2]++))
+fi
+
+new_version="${a[0]}.${a[1]}.${a[2]}"
+
+echo "New version: ${new_version}"
+
+sed -i s/\"${oa[0]}\.${oa[1]}\.${oa[2]}\"/\"${a[0]}\.${a[1]}\.${a[2]}\"/g src/opencensus.app.src
+# sed -i s/\"${oa[0]}\.${oa[1]}\.${oa[2]}\"/\"${a[0]}\.${a[1]}\.${a[2]}\"/g mix.exs
+sed -i s/@version\ ${oa[0]}\.${oa[1]}\.${oa[2]}/@version\ ${a[0]}\.${a[1]}\.${a[2]}/g doc/overview.edoc
+rebar3 edoc
+
+git add mix.exs src/opencensus.app.src
+git add README.md
+git add doc
+git commit -m "Bump to v${new_version}"
+
+TAG_MESSAGE=${1:-"New version: v${new_version}"}
+
+git tag -a "v${new_version}" -m "${TAG_MESSAGE}"
+git push origin master
+git push origin "v${new_version}"


### PR DESCRIPTION
I noticed that our README, hex.pm package and git tag versions are out of sync.
Here I'm proposing to use increment-version script I've been using for some time.
Adopting this in the default form will require to maintain version in app.src, instead of `git`.

Usage:
```
-p - increment patch version
-m - increment minor version
-M - increment major version
```

Docs automatically regenerated, committed and pushed along with a new git tag.
mix.exs update line commented for now.