### PR TITLE
Measures

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -200,6 +200,7 @@ $ rebar3 protobuf compile
 <tr><td><a href="oc_stat_config.md" class="module">oc_stat_config</a></td></tr>
 <tr><td><a href="oc_stat_exporter.md" class="module">oc_stat_exporter</a></td></tr>
 <tr><td><a href="oc_stat_exporter_stdout.md" class="module">oc_stat_exporter_stdout</a></td></tr>
+<tr><td><a href="oc_stat_measure.md" class="module">oc_stat_measure</a></td></tr>
 <tr><td><a href="oc_stat_view.md" class="module">oc_stat_view</a></td></tr>
 <tr><td><a href="oc_std_encoder.md" class="module">oc_std_encoder</a></td></tr>
 <tr><td><a href="oc_tag_ctx_binary.md" class="module">oc_tag_ctx_binary</a></td></tr>

--- a/doc/edoc-info
+++ b/doc/edoc-info
@@ -6,7 +6,7 @@
           oc_span_ctx_binary,oc_span_ctx_header,oc_stat,oc_stat_aggregation,
           oc_stat_aggregation_count,oc_stat_aggregation_distribution,
           oc_stat_aggregation_latest,oc_stat_aggregation_sum,oc_stat_config,
-          oc_stat_exporter,oc_stat_exporter_stdout,oc_stat_view,
-          oc_std_encoder,oc_tag_ctx_binary,oc_tag_ctx_header,oc_tags,oc_trace,
-          oc_trace_pb,oc_transform,ocp,opencensus,opencensus_app,
-          opencensus_sup]}.
+          oc_stat_exporter,oc_stat_exporter_stdout,oc_stat_measure,
+          oc_stat_view,oc_std_encoder,oc_tag_ctx_binary,oc_tag_ctx_header,
+          oc_tags,oc_trace,oc_trace_pb,oc_transform,ocp,opencensus,
+          opencensus_app,opencensus_sup]}.

--- a/doc/oc_stat_aggregation.md
+++ b/doc/oc_stat_aggregation.md
@@ -1,6 +1,9 @@
 
 
 # Module oc_stat_aggregation #
+* [Description](#description)
+
+Aggregation represents a data aggregation method.
 
 __This module defines the `oc_stat_aggregation` behaviour.__<br /> Required callback functions: `init/3`, `type/0`, `add_sample/4`, `export/2`, `clear_rows/2`.
 

--- a/doc/oc_stat_aggregation_count.md
+++ b/doc/oc_stat_aggregation_count.md
@@ -1,10 +1,18 @@
 
 
 # Module oc_stat_aggregation_count #
+* [Description](#description)
 * [Function Index](#index)
 * [Function Details](#functions)
 
-<a name="index"></a>
+Count indicates that data collected and aggregated
+with this method will be turned into a count value.
+
+<a name="description"></a>
+
+## Description ##
+For example, total number of accepted requests can be
+aggregated by using Count.<a name="index"></a>
 
 ## Function Index ##
 

--- a/doc/oc_stat_aggregation_distribution.md
+++ b/doc/oc_stat_aggregation_distribution.md
@@ -1,8 +1,12 @@
 
 
 # Module oc_stat_aggregation_distribution #
+* [Description](#description)
 * [Function Index](#index)
 * [Function Details](#functions)
+
+Distribution indicates that the desired aggregation is
+a histogram distribution.
 
 <a name="index"></a>
 

--- a/doc/oc_stat_aggregation_latest.md
+++ b/doc/oc_stat_aggregation_latest.md
@@ -1,8 +1,11 @@
 
 
 # Module oc_stat_aggregation_latest #
+* [Description](#description)
 * [Function Index](#index)
 * [Function Details](#functions)
+
+Latest indicates that only last data point is saved.
 
 <a name="index"></a>
 

--- a/doc/oc_stat_aggregation_sum.md
+++ b/doc/oc_stat_aggregation_sum.md
@@ -1,10 +1,18 @@
 
 
 # Module oc_stat_aggregation_sum #
+* [Description](#description)
 * [Function Index](#index)
 * [Function Details](#functions)
 
-<a name="index"></a>
+Sum indicates that data collected and aggregated
+with this method will be summed up.
+
+<a name="description"></a>
+
+## Description ##
+For example, accumulated request bytes can be aggregated by using
+Sum.<a name="index"></a>
 
 ## Function Index ##
 

--- a/doc/oc_stat_measure.md
+++ b/doc/oc_stat_measure.md
@@ -1,0 +1,74 @@
+
+
+# Module oc_stat_measure #
+* [Description](#description)
+* [Data Types](#types)
+* [Function Index](#index)
+* [Function Details](#functions)
+
+Measure represents a type of metric to be tracked and recorded.
+
+<a name="description"></a>
+
+## Description ##
+For example, latency, request Mb/s, and response Mb/s are measures
+to collect from a server.
+<a name="types"></a>
+
+## Data Types ##
+
+
+
+
+### <a name="type-description">description()</a> ###
+
+
+<pre><code>
+description() = binary() | string()
+</code></pre>
+
+
+
+
+### <a name="type-name">name()</a> ###
+
+
+<pre><code>
+name() = atom() | binary() | string()
+</code></pre>
+
+
+
+
+### <a name="type-unit">unit()</a> ###
+
+
+<pre><code>
+unit() = atom()
+</code></pre>
+
+<a name="index"></a>
+
+## Function Index ##
+
+
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#new-3">new/3</a></td><td>
+Creates and registers a measure.</td></tr></table>
+
+
+<a name="functions"></a>
+
+## Function Details ##
+
+<a name="new-3"></a>
+
+### new/3 ###
+
+<pre><code>
+new(Name::<a href="#type-name">name()</a>, Description::<a href="#type-description">description()</a>, Unit::<a href="#type-unit">unit()</a>) -&gt; <a href="oc_stat_view.md#type-measure">oc_stat_view:measure()</a>
+</code></pre>
+<br />
+
+Creates and registers a measure. If a measure with the same name
+already exists, old measure returned.
+

--- a/doc/oc_stat_view.md
+++ b/doc/oc_stat_view.md
@@ -71,7 +71,7 @@ Creates a View from a map.</td></tr><tr><td valign="top"><a href="#new-5">new/5<
 Creates a View.</td></tr><tr><td valign="top"><a href="#preload-1">preload/1</a></td><td>
 Loads and subscribes views from the <code>List</code> in one shot.</td></tr><tr><td valign="top"><a href="#register-1">register/1</a></td><td>
 Registers the view.</td></tr><tr><td valign="top"><a href="#register-5">register/5</a></td><td>
-Registers the view created from arguments.</td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-1">subscribe/1</a></td><td>
+Registers the view created from arguments.</td></tr><tr><td valign="top"><a href="#register_measure-3">register_measure/3</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-1">subscribe/1</a></td><td>
 Subscribe the View, When subscribed, a view can aggregate measure data and export it.</td></tr><tr><td valign="top"><a href="#subscribe-5">subscribe/5</a></td><td>
 A shortcut.</td></tr><tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr><tr><td valign="top"><a href="#unsubscribe-1">unsubscribe/1</a></td><td>
 Unsubscribes the View.</td></tr></table>
@@ -206,6 +206,12 @@ Registers the view. Aggregation initialized with AggregationOptions.
 `register(Name, Measure, Description, Tags, Aggregation) -> any()`
 
 Registers the view created from arguments.
+
+<a name="register_measure-3"></a>
+
+### register_measure/3 ###
+
+`register_measure(Name, Description, Unit) -> any()`
 
 <a name="start_link-0"></a>
 

--- a/src/oc_stat_aggregation.erl
+++ b/src/oc_stat_aggregation.erl
@@ -1,3 +1,22 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2018, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% Aggregation represents a data aggregation method.
+%% @end
+%%%-----------------------------------------------------------------------
+
 -module(oc_stat_aggregation).
 
 -export_types(data/0).

--- a/src/oc_stat_aggregation_count.erl
+++ b/src/oc_stat_aggregation_count.erl
@@ -1,3 +1,25 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2018, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% Count indicates that data collected and aggregated
+%% with this method will be turned into a count value.
+%% For example, total number of accepted requests can be
+%% aggregated by using Count.
+%% @end
+%%%-----------------------------------------------------------------------
+
 -module(oc_stat_aggregation_count).
 
 -include("opencensus.hrl").

--- a/src/oc_stat_aggregation_distribution.erl
+++ b/src/oc_stat_aggregation_distribution.erl
@@ -1,3 +1,23 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2018, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% Distribution indicates that the desired aggregation is
+%% a histogram distribution.
+%% @end
+%%%-----------------------------------------------------------------------
+
 -module(oc_stat_aggregation_distribution).
 
 -export([init/3,

--- a/src/oc_stat_aggregation_latest.erl
+++ b/src/oc_stat_aggregation_latest.erl
@@ -1,3 +1,22 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2018, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% Latest indicates that only last data point is saved.
+%% @end
+%%%-----------------------------------------------------------------------
+
 -module(oc_stat_aggregation_latest).
 
 -export([init/3,

--- a/src/oc_stat_aggregation_sum.erl
+++ b/src/oc_stat_aggregation_sum.erl
@@ -1,3 +1,25 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2018, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% Sum indicates that data collected and aggregated
+%% with this method will be summed up.
+%% For example, accumulated request bytes can be aggregated by using
+%% Sum.
+%% @end
+%%%-----------------------------------------------------------------------
+
 -module(oc_stat_aggregation_sum).
 
 -export([init/3,

--- a/src/oc_stat_measure.erl
+++ b/src/oc_stat_measure.erl
@@ -1,0 +1,40 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2018, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% Measure represents a type of metric to be tracked and recorded.
+%% For example, latency, request Mb/s, and response Mb/s are measures
+%% to collect from a server.
+%% @end
+%%%-----------------------------------------------------------------------
+-module(oc_stat_measure).
+
+-export([new/3]).
+
+-export_types([name/0,
+               description/0,
+               unit/0]).
+
+-type name() :: atom() | binary() | string().
+-type description() :: binary() | string().
+-type unit() :: atom().
+
+
+%% @doc
+%% Creates and registers a measure. If a measure with the same name
+%% already exists, old measure returned.
+%% @end
+-spec new(name(), description(), unit()) -> oc_stat_view:measure().
+new(Name, Description, Unit) ->
+    oc_stat_view:register_measure(Name, Description, Unit).


### PR DESCRIPTION
Here measures mostly used as a form of 'forward declaration' for subscribed views.
At least eliminates this (expected to be very common) case when people make typos in their measure names when recording values.

Also:
 - added Tristan and Ilya to the authors list (moved to a separate PR);
 - added Apache 2 headers together with brief module docs;
 - regenerated docs.