### PR TITLE
Provide default oc_sample_impl that errors with a message

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -185,6 +185,7 @@ $ rebar3 protobuf compile
 <tr><td><a href="oc_reporter_zipkin.md" class="module">oc_reporter_zipkin</a></td></tr>
 <tr><td><a href="oc_sampler.md" class="module">oc_sampler</a></td></tr>
 <tr><td><a href="oc_sampler_always.md" class="module">oc_sampler_always</a></td></tr>
+<tr><td><a href="oc_sampler_impl.md" class="module">oc_sampler_impl</a></td></tr>
 <tr><td><a href="oc_sampler_never.md" class="module">oc_sampler_never</a></td></tr>
 <tr><td><a href="oc_sampler_probability.md" class="module">oc_sampler_probability</a></td></tr>
 <tr><td><a href="oc_server.md" class="module">oc_server</a></td></tr>

--- a/doc/edoc-info
+++ b/doc/edoc-info
@@ -2,11 +2,11 @@
 {application,opencensus}.
 {modules,[oc_reporter,oc_reporter_noop,oc_reporter_sequential,
           oc_reporter_stdout,oc_reporter_zipkin,oc_sampler,oc_sampler_always,
-          oc_sampler_never,oc_sampler_probability,oc_server,oc_span,
-          oc_span_ctx_binary,oc_span_ctx_header,oc_stat,oc_stat_aggregation,
-          oc_stat_aggregation_count,oc_stat_aggregation_distribution,
-          oc_stat_aggregation_latest,oc_stat_aggregation_sum,oc_stat_config,
-          oc_stat_exporter,oc_stat_exporter_stdout,oc_stat_measure,
-          oc_stat_view,oc_std_encoder,oc_tag_ctx_binary,oc_tag_ctx_header,
-          oc_tags,oc_trace,oc_trace_pb,oc_transform,ocp,opencensus,
-          opencensus_app,opencensus_sup]}.
+          oc_sampler_impl,oc_sampler_never,oc_sampler_probability,oc_server,
+          oc_span,oc_span_ctx_binary,oc_span_ctx_header,oc_stat,
+          oc_stat_aggregation,oc_stat_aggregation_count,
+          oc_stat_aggregation_distribution,oc_stat_aggregation_latest,
+          oc_stat_aggregation_sum,oc_stat_config,oc_stat_exporter,
+          oc_stat_exporter_stdout,oc_stat_measure,oc_stat_view,oc_std_encoder,
+          oc_tag_ctx_binary,oc_tag_ctx_header,oc_tags,oc_trace,oc_trace_pb,
+          oc_transform,ocp,opencensus,opencensus_app,opencensus_sup]}.

--- a/doc/oc_sampler_impl.md
+++ b/doc/oc_sampler_impl.md
@@ -1,0 +1,24 @@
+
+
+# Module oc_sampler_impl #
+* [Function Index](#index)
+* [Function Details](#functions)
+
+<a name="index"></a>
+
+## Function Index ##
+
+
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#should_sample-3">should_sample/3</a></td><td></td></tr></table>
+
+
+<a name="functions"></a>
+
+## Function Details ##
+
+<a name="should_sample-3"></a>
+
+### should_sample/3 ###
+
+`should_sample(TraceId, SpanId, Enabled) -> any()`
+

--- a/src/oc_sampler.erl
+++ b/src/oc_sampler.erl
@@ -25,6 +25,8 @@
 -export([init/1,
          should_sample/3]).
 
+-dialyzer({nowarn_function, should_sample/3}).
+
 -include_lib("syntax_tools/include/merl.hrl").
 
 -callback init(term()) -> term().

--- a/src/oc_sampler_impl.erl
+++ b/src/oc_sampler_impl.erl
@@ -21,9 +21,7 @@
 
 -export([should_sample/3]).
 
-should_sample(TraceId, _SpanId, _Enabled) ->
-    case TraceId of
-        _ when TraceId < 0 -> true;
-        _ when TraceId == 0 -> false;
-        _ -> erlang:error("Please start opencensus app first")
-    end.
+-dialyzer({nowarn_function, should_sample/3}).
+
+should_sample(_TraceId, _SpanId, _Enabled) ->
+    erlang:error("Please start opencensus app first").

--- a/src/oc_sampler_impl.erl
+++ b/src/oc_sampler_impl.erl
@@ -1,0 +1,25 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2018, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%------------------------------------------------------------------------
+
+
+-module(oc_sampler_impl).
+
+-export([should_sample/3]).
+
+should_sample(_TraceId, _SpanId, _Enabled) ->
+    erlang:error("Please start opencensus app first").

--- a/src/oc_sampler_impl.erl
+++ b/src/oc_sampler_impl.erl
@@ -21,5 +21,9 @@
 
 -export([should_sample/3]).
 
-should_sample(_TraceId, _SpanId, _Enabled) ->
-    erlang:error("Please start opencensus app first").
+should_sample(TraceId, _SpanId, _Enabled) ->
+    case TraceId of
+        _ when TraceId < 0 -> true;
+        _ when TraceId == 0 -> false;
+        _ -> erlang:error("Please start opencensus app first")
+    end.

--- a/src/oc_trace.erl
+++ b/src/oc_trace.erl
@@ -51,6 +51,8 @@
 
          set_status/3]).
 
+-dialyzer({nowarn_function, update_trace_options/2}).
+
 -include("opencensus.hrl").
 
 %% sampling bit is the first bit in 8-bit trace options


### PR DESCRIPTION
Right now if opencensus isn't started error looks like this:

```
{error,undef,
  [{oc_sampler_impl,should_sample,
     150434719869329625117600098438147726757,
     undefined,false],
[]},
```

And the next thing people usually do is they try to find this oc_sample_impl, where it's called, etc.

Usually it happens during testing, because spans already in the code and therefore sampler is called. 

This commit provides default oc_sample_impl that throws an error. Another option is to start opencensus here but imo too magic. 