### PR TITLE
WIP: Measures codegen

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -14,7 +14,10 @@
                   {elvis_style, function_naming_convention, #{regex => "^_{0,2}([a-z][a-z0-9]*_?)*_{0,2}$"}},
                   %% sequential reporter calls other reporters dynamically
                   %% stat view proxies measures
-                  {elvis_style, invalid_dynamic_call, #{ignore => [oc_reporter_sequential, oc_stat_view, oc_stat]}}],
+                  {elvis_style, invalid_dynamic_call, #{ignore => [oc_reporter_sequential, %% loops over reporters
+                                                                   oc_stat_view, %% calls aggragtions
+                                                                   oc_stat_measure %% calls generated modules
+                                                                  ]}}],
         ruleset => erl_files
        },
        #{dirs => ["test"],

--- a/elvis.config
+++ b/elvis.config
@@ -14,7 +14,7 @@
                   {elvis_style, function_naming_convention, #{regex => "^_{0,2}([a-z][a-z0-9]*_?)*_{0,2}$"}},
                   %% sequential reporter calls other reporters dynamically
                   %% stat view proxies measures
-                  {elvis_style, invalid_dynamic_call, #{ignore => [oc_reporter_sequential, oc_stat_view]}}],
+                  {elvis_style, invalid_dynamic_call, #{ignore => [oc_reporter_sequential, oc_stat_view, oc_stat]}}],
         ruleset => erl_files
        },
        #{dirs => ["test"],

--- a/include/opencensus.hrl
+++ b/include/opencensus.hrl
@@ -121,3 +121,5 @@
 -type measure_name()        :: atom() | binary() | string().
 -type aggregation()         :: module().
 -type aggregation_options() :: any().
+
+-define(STAT_SERVER, oc_stat).

--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,10 @@
           {edoc_opts,
            [{doclet, edown_doclet},
             {dir, "doc"},
-            {subpackages, true}]}]}]}.
+            {subpackages, true}]}]},
+  {benchmark, [{src_dirs, ["src", "benchmark"]},
+               {deps, [{'erlang-color',
+                        {git, "https://github.com/julianduque/erlang-color", {branch, "master"}}}]}]}]}.
 
 {overrides, [{override, rebar3_gpb_plugin, [{deps, [{gpb, "4.1.2"}]}]}]}.
 

--- a/src/oc_stat.erl
+++ b/src/oc_stat.erl
@@ -21,30 +21,89 @@
          record/3,
          export/0]).
 
+-export([start_link/0,
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         code_change/3,
+         terminate/2]).
+
+-record(state, {}).
+
 -include("opencensus.hrl").
+
+-define(RECORD(Tags, MeasureName, Value),
+        begin
+            Module = oc_stat_view:measure_module(MeasureName),
+            Module:record(Tags, Value),
+            ok
+        end).
 
 %% @doc Records one or multiple measurements with the same tags at once.
 %% If there are any tags in the context, measurements will be tagged with them.
--spec record(ctx:t() | oc_tags:tags(), measure_name(), number()) -> ok.
+-spec record(ctx:t() | oc_tags:tags(), oc_stat_measure:name(), number()) -> ok.
 record(Tags, MeasureName, Value) when is_map(Tags) ->
-    Module = oc_stat_view:measure_module(MeasureName),
-    Module:record(Tags, Value),
-    ok;
+    ?RECORD(Tags, MeasureName, Value);
 record(Ctx, MeasureName, Value)->
     Tags = oc_tags:from_ctx(Ctx),
-    record(Tags, MeasureName, Value).
+    ?RECORD(Tags, MeasureName, Value).
 
--spec record(ctx:t() | oc_tags:tags(), [{measure_name(), number()}]) -> ok.
+-spec record(ctx:t() | oc_tags:tags(), [{oc_stat_measure:name(), number()}]) -> ok.
 record(Tags, Measures) when is_map(Tags) ->
-    [record(Tags, MeasureName, Value)
-     || {MeasureName, Value} <- Measures],
+    [?RECORD(Tags, MeasureName, Value) || {MeasureName, Value} <- Measures],
     ok;
 record(Ctx, Measures) ->
     Tags = oc_tags:from_ctx(Ctx),
     record(Tags, Measures).
 
-
 %% @doc Exports view_data of all subscribed views
 -spec export() -> oc_stat_view:view_data().
 export() ->
     [oc_stat_view:export(View) || View <- oc_stat_view:all_subscribed()].
+
+%% gen_server implementation
+
+%% @private
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% @private
+init(_Args) ->
+    process_flag(trap_exit, true),
+    ok = oc_stat_view:'__init_backend__'(),
+    ok = oc_stat_measure:'__init_backend__'(),
+    ok = oc_stat_view:preload(),
+    {ok, #state{}}.
+
+%% @private
+handle_call({measure_register, Measure}, _From, State) ->
+    {reply, oc_stat_measure:register_(Measure), State};
+handle_call({view_register, View}, _From, State) ->
+    {reply, oc_stat_view:register_(View), State};
+handle_call({view_deregister, Name}, _From, State) ->
+    oc_stat_view:deregister_(Name),
+    {reply, ok, State};
+handle_call({view_subscribe, Name}, _From,  State) ->
+    {reply, oc_stat_view:subscribe_(Name), State};
+handle_call({view_unsubscribe, Name}, _From, State) ->
+    {reply, oc_stat_view:unsubscribe_(Name), State};
+handle_call(_, _From, State) ->
+    {noreply, State}.
+
+%% @private
+handle_cast(_, State) ->
+    {noreply, State}.
+
+%% @private
+handle_info(_, State) ->
+    {noreply, State}.
+
+%% @private
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% @private
+terminate(_, _) ->
+    oc_stat_measure:terminate_(),
+    ok.

--- a/src/oc_stat.erl
+++ b/src/oc_stat.erl
@@ -35,7 +35,7 @@
 
 -define(RECORD(Tags, MeasureName, Value),
         begin
-            Module = oc_stat_view:measure_module(MeasureName),
+            Module = oc_stat_measure:measure_module(MeasureName),
             Module:record(Tags, Value),
             ok
         end).
@@ -60,7 +60,7 @@ record(Ctx, Measures) ->
 %% @doc Exports view_data of all subscribed views
 -spec export() -> oc_stat_view:view_data().
 export() ->
-    [oc_stat_view:export(View) || View <- oc_stat_view:all_subscribed()].
+    [oc_stat_view:export(View) || View <- oc_stat_view:all_subscribed_()].
 
 %% gen_server implementation
 
@@ -73,12 +73,13 @@ init(_Args) ->
     process_flag(trap_exit, true),
     ok = oc_stat_view:'__init_backend__'(),
     ok = oc_stat_measure:'__init_backend__'(),
-    ok = oc_stat_view:preload(),
     {ok, #state{}}.
 
 %% @private
 handle_call({measure_register, Measure}, _From, State) ->
     {reply, oc_stat_measure:register_(Measure), State};
+handle_call({view_register_subscribe, View}, _From, State) ->
+    {reply, oc_stat_view:register_subscribe_(View), State};
 handle_call({view_register, View}, _From, State) ->
     {reply, oc_stat_view:register_(View), State};
 handle_call({view_deregister, Name}, _From, State) ->

--- a/src/oc_stat.erl
+++ b/src/oc_stat.erl
@@ -27,8 +27,8 @@
 %% If there are any tags in the context, measurements will be tagged with them.
 -spec record(ctx:t() | oc_tags:tags(), measure_name(), number()) -> ok.
 record(Tags, MeasureName, Value) when is_map(Tags) ->
-    [oc_stat_view:add_sample(ViewSub, Tags, Value)
-     || ViewSub <- oc_stat_view:measure_views(MeasureName)],
+    Module = oc_stat_view:measure_module(MeasureName),
+    Module:record(Tags, Value),
     ok;
 record(Ctx, MeasureName, Value)->
     Tags = oc_tags:from_ctx(Ctx),

--- a/src/oc_stat_measure.erl
+++ b/src/oc_stat_measure.erl
@@ -20,7 +20,14 @@
 %%%-----------------------------------------------------------------------
 -module(oc_stat_measure).
 
--export([new/3]).
+-export([new/3,
+         module_name/1,
+         maybe_module_name/1,
+         regen_record/2,
+         delete_measure/1,
+         prepare_tags/1]).
+
+-export([parse_transform/2]).
 
 -export_types([name/0,
                description/0,
@@ -38,3 +45,115 @@
 -spec new(name(), description(), unit()) -> oc_stat_view:measure().
 new(Name, Description, Unit) ->
     oc_stat_view:register_measure(Name, Description, Unit).
+
+-spec module_name(name()) -> module().
+module_name(Name) when is_atom(Name) ->
+    list_to_atom(module_name_str(Name)).
+
+module_name_str(Name) when is_atom(Name) ->
+    name_template(atom_to_list(Name));
+module_name_str(Name) when is_binary(Name) ->
+    name_template(binary_to_list(Name));
+module_name_str(Name) when is_list(Name) ->
+    name_template(binary_to_list(iolist_to_binary(Name))).
+
+name_template(Name) ->
+    lists:flatten(["$_MEASURE_", Name]).
+
+maybe_module_name(Name) ->
+    list_to_existing_atom(module_name_str(Name)).
+
+regen_record(Name, VSs) ->
+    regen_module(Name, gen_add_sample_calls(VSs), erl_parse:abstract(VSs)).
+
+delete_measure(Name) ->
+    ErrorA = erl_parse:abstract({unknown_measure, Name}),
+    regen_module(Name,
+                 gen_add_sample_calls([])
+                 ++ [{call, 1,
+                      {remote, 1, {atom, 1, erlang}, {atom, 1, error}},
+                      [ErrorA]}],
+                 {call, 1,
+                  {remote, 1, {atom, 1, erlang}, {atom, 1, error}},
+                  [ErrorA]}).
+
+prepare_tags(Tags) when is_map(Tags) ->
+    Tags;
+prepare_tags(Ctx) ->
+    oc_tags:from_ctx(Ctx).
+
+regen_module(Name, RecordBody, Subs) ->
+    ModuleName = module_name(Name),
+    ModuleNameStr = atom_to_list(ModuleName),
+    {ok, Module, Binary} =
+        compile:forms(
+          [{attribute, 1, file,
+            {ModuleNameStr,
+             1}},
+           {attribute, 1, module, ModuleName},
+           {attribute, 1, export,
+            [{record, 2}]},
+           {attribute, 1, export,
+            [{subs, 0}]},
+           {function, 1, record, 2,
+            [{clause, 1, [{var, 1, 'ContextTags'}, {var, 1, 'Value'}], [],
+              RecordBody ++ [{atom, 1, ok}]
+             }]},
+           {function, 1, subs, 0,
+            [{clause, 1, [], [],
+              [Subs]
+             }]},
+           {eof, 2}]),
+
+    {module, Module} = code:load_binary(Module, ModuleNameStr, Binary).
+
+gen_add_sample_calls([]) ->
+    [{match, 1, {var, 1, '_'}, {var, 1, 'ContextTags'}},
+     {match, 1, {var, 1, '_'}, {var, 1, 'Value'}}];
+gen_add_sample_calls(VSs) ->
+    lists:map(fun oc_stat_view:gen_add_sample/1, VSs).
+
+parse_transform(Forms, _Options) ->
+    HiForms = lists:map(fun walk_ast/1, Forms),
+    HiForms.
+
+walk_ast({function, Line, Name, Args, Clauses}) ->
+    {function, Line, Name, Args, walk_clauses([], Clauses)};
+
+walk_ast(Form) ->
+    Form.
+
+walk_clauses(Acc, []) ->
+    lists:reverse(Acc);
+walk_clauses(Acc, [{clause, Line, Arguments, Guards, Body}|Rest]) ->
+    walk_clauses([{clause, Line, Arguments, Guards, walk_body([], Body)}|Acc], Rest).
+
+walk_body(Acc, []) ->
+    lists:reverse(Acc);
+walk_body(Acc, [H|R]) ->
+    walk_body([transform_statement(H)|Acc], R).
+
+transform_statement({call, Line,
+                     {remote, _, {atom, _, oc_stat}, {atom, _, record}},
+                     [Tags, {atom, _, MeasureName}, Value]}=_Stmt) ->
+    measure_module_record_call(Line, Tags, MeasureName, Value);
+transform_statement({call, Line,
+                     {remote, _, {atom, _, oc_stat}, {atom, _, record}},
+                     [Tags,  Measures0]}=_Stmt) ->
+
+    Measures = erl_syntax:list_elements(Measures0),
+    %% TODO: prepare tags first
+    {block, Line,
+     [measure_module_record_call(Line, Tags, MeasureName, Value)
+      || {tuple, _, [{atom, _, MeasureName}, Value]} <- Measures]};
+transform_statement(Stmt) when is_tuple(Stmt) ->
+    list_to_tuple(transform_statement(tuple_to_list(Stmt)));
+transform_statement(Stmt) when is_list(Stmt) ->
+    [transform_statement(S) || S <- Stmt];
+transform_statement(Stmt) ->
+    Stmt.
+
+measure_module_record_call(Line, Tags, MeasureName, Value) ->
+    {call, Line,
+     {remote, Line, {atom, Line, module_name(MeasureName)}, {atom, Line, record}},
+     [{call, Line, {remote, Line, {atom, Line, ?MODULE}, {atom, Line, prepare_tags}}, [Tags]}, Value]}.

--- a/src/oc_stat_view.erl
+++ b/src/oc_stat_view.erl
@@ -29,26 +29,20 @@
          subscribe/5,
          subscribe/1,
          unsubscribe/1,
-         is_subscribed/1]).
-
--export([register_measure/3]).
+         is_subscribed/1,
+         export/1]).
 
 -export([preload/1]).
 
--export([measure_module/1,
-         add_sample/3,
-         gen_add_sample/1,
-         tag_values/2,
-         all_subscribed/0,
-         export/1]).
+%% unsafe api, needs snychronization
+-export([register_/1,
+         deregister_/1,
+         subscribe_/1,
+         unsubscribe_/1]).
 
--export([start_link/0,
-         init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         code_change/3,
-         terminate/2]).
+-export([gen_add_sample_/1,
+         tag_values_/2,
+         all_subscribed_/0]).
 
 -export_types([name/0,
                description/0,
@@ -66,26 +60,19 @@
 -define(VIEWS_TABLE, ?MODULE).
 -define(MEASURES_TABLE, oc_stat_view_subs).
 
--record(view, {name                :: name() | '_',
-               measure             :: measure_name() | '_',
-               subscribed          :: boolean(),
-               description         :: description() | '_',
-               ctags               :: oc_tags:tags() | '_',
-               tags                :: [oc_tags:key()] | '_',
-               aggregation         :: aggregation() | '_',
-               aggregation_options :: aggregation_options() | '_'}).
+-record(view, {name                        :: name() | '_',
+               measure                     :: measure_name() | '_',
+               subscribed          = false :: boolean(),
+               description         = ""    :: description() | '_',
+               ctags               = #{}   :: oc_tags:tags() | '_',
+               tags                = []    :: [oc_tags:key()] | '_',
+               aggregation                 :: aggregation() | '_',
+               aggregation_options = []    :: aggregation_options() | '_'}).
 
 -record(v_s, {name                :: name(),
               tags                :: [oc_tags:key()],
               aggregation         :: aggregation(),
               aggregation_options :: aggregation_options()}).
-
--record(measure, {name :: oc_stat_measure:name(),
-                  module :: module(),
-                  description :: oc_stat_measure:description(),
-                  unit :: oc_stat_measure:unit()}).
-
--record(state, {}).
 
 -type name()        :: atom() | binary() | string().
 -type description() :: binary() | string().
@@ -114,7 +101,6 @@ new(Name, Measure, Description, Tags, Aggregation) ->
     #view{name=Name,
           measure=Measure,
           description=Description,
-          subscribed=false,
           ctags=CTags,
           tags=Keys,
           aggregation=AggregationModule,
@@ -132,7 +118,7 @@ register(Name, Measure, Description, Tags, Aggregation) ->
 %% @end
 -spec register(view()) -> {ok, view()} | {error, any()}.
 register(#view{}=View) ->
-    gen_server:call(?MODULE, {register, View}).
+    gen_server:call(?STAT_SERVER, {view_register, View}).
 
 %% @doc
 %% Deregisters the view. If subscribed, unsubscribes and therefore
@@ -142,7 +128,7 @@ register(#view{}=View) ->
 deregister(#view{name=Name}) ->
     deregister(Name);
 deregister(Name) ->
-    gen_server:call(?MODULE, {deregister, Name}).
+    gen_server:call(?STAT_SERVER, {view_deregister, Name}).
 
 %% @doc
 %% Returns true if the view is registered.
@@ -173,7 +159,7 @@ subscribe(Name, Measure, Description, Tags, Aggregation) ->
 subscribe(#view{name=Name}) ->
     subscribe(Name);
 subscribe(Name) ->
-    gen_server:call(?MODULE, {subscribe, Name}).
+    gen_server:call(?STAT_SERVER, {view_subscribe, Name}).
 
 %% @doc
 %% Unsubscribes the View. When unsubscribed a view no longer aggregates measure data
@@ -183,7 +169,7 @@ subscribe(Name) ->
 unsubscribe(#view{name=Name}) ->
     unsubscribe(Name);
 unsubscribe(Name) ->
-    gen_server:call(?MODULE, {unsubscribe, Name}).
+    gen_server:call(?STAT_SERVER, {view_unsubscribe, Name}).
 
 %% @doc
 %% Returns true if the view is exporting data by subscription.
@@ -197,16 +183,6 @@ is_subscribed(Name) ->
             Subscribed;
         _ ->
             false
-    end.
-
-register_measure(Name, Description, Unit) ->
-    case ets:lookup(?MEASURES_TABLE, Name) of
-        [Measure] -> Measure;
-        _ -> gen_server:call(?MODULE, {register_measure,
-                                       #measure{name=Name,
-                                                module=oc_stat_measure:module_name(Name),
-                                                description=Description,
-                                                unit=Unit}})
     end.
 
 %% @doc
@@ -225,40 +201,6 @@ preload(List) ->
          end
      end || V <- List].
 
-%% @private
-measure_module(Measure) ->
-    case ets:lookup(?MEASURES_TABLE, Measure) of
-        [#measure{module=Module}] ->
-            Module;
-        _ -> erlang:error({unknown_measure, Measure})
-    end.
-
-%% @private
--spec add_sample(v_s(), oc_tags:tags(), number()) -> ok.
-add_sample(ViewSub, ContextTags, Value) ->
-    TagValues = tag_values(ContextTags, ViewSub#v_s.tags),
-    AM = ViewSub#v_s.aggregation,
-    AM:add_sample(ViewSub#v_s.name, TagValues, Value, ViewSub#v_s.aggregation_options),
-    ok.
-
-%% @private
-gen_add_sample(ViewSub) ->
-    TagsA = erl_parse:abstract(ViewSub#v_s.tags),
-    ViewNameA = erl_parse:abstract(ViewSub#v_s.name),
-    AggregationModuleA = erl_parse:abstract(ViewSub#v_s.aggregation),
-    AggregationOptionsA = erl_parse:abstract(ViewSub#v_s.aggregation_options),
-
-    {call, 1, {remote, 1, AggregationModuleA, {atom, 1, add_sample}},
-     [ViewNameA,
-      {call, 1, {remote, 1, {atom, 1, oc_stat_view}, {atom, 1, tag_values}},
-       [{var, 1, 'ContextTags'}, TagsA]},
-      {var, 1, 'Value'},
-      AggregationOptionsA]}.
-
-%% @private
-all_subscribed() ->
-    ets:match_object(?VIEWS_TABLE, #view{subscribed=true, _='_'}).
-
 %% @doc
 %% Returns a snapshot of the View's data.
 %% @end
@@ -273,167 +215,136 @@ export(#view{name=Name, description=Description,
       tags => lists:reverse(Keys),
       data => AggregationModule:export(Name, AggregationOptions)}.
 
-%% gen_server implementation
+%% =============================================================================
+%% internal
+%% =============================================================================
 
-start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+%% @private
+gen_add_sample_(ViewSub) ->
+    TagsA = erl_parse:abstract(ViewSub#v_s.tags),
+    ViewNameA = erl_parse:abstract(ViewSub#v_s.name),
+    AggregationModuleA = erl_parse:abstract(ViewSub#v_s.aggregation),
+    AggregationOptionsA = erl_parse:abstract(ViewSub#v_s.aggregation_options),
 
-init(_Args) ->
-    process_flag(trap_exit, true),
-    ok = '__init_backend__'(),
-    preload(oc_stat_config:views()),
-    {ok, #state{}}.
+    {call, 1, {remote, 1, AggregationModuleA, {atom, 1, add_sample}},
+     [ViewNameA,
+      {call, 1, {remote, 1, {atom, 1, oc_stat_view}, {atom, 1, tag_values}},
+       [{var, 1, 'ContextTags'}, TagsA]},
+      {var, 1, 'Value'},
+      AggregationOptionsA]}.
 
-handle_call({register, #view{measure=Measure,
-                             name=Name,
-                             description=Description,
-                             ctags=CTags,
-                             tags=Keys,
-                             aggregation=AggregationModule}=View}, _From, State) ->
+%% @private
+all_subscribed_() ->
+    ets:match_object(?VIEWS_TABLE, #view{subscribed=true, _='_'}).
+
+%% @private
+register_(#view{name=Name}=View) ->
+    SView = View#view{subscribed=true},
     case ets:lookup(?VIEWS_TABLE, Name) of
-        [#view{measure=Measure,
-               name=Name,
-               description=Description,
-               ctags=CTags,
-               tags=Keys,
-               aggregation=AggregationModule}=OldView] ->
-            {reply, {ok, OldView}, State};
+        [View] ->
+            {ok, View};
+        [SView] ->
+            {ok, SView};
         [_] ->
-            {reply, {error, {already_exists, Name}}, State};
+            {error, {view_already_exists, Name}};
         _ ->
-            {reply, register_(View), State}
-    end;
-handle_call({deregister, Name}, _From, State) ->
+            try init_view_aggregation(View) of
+                IView ->
+                    ets:insert(?VIEWS_TABLE, IView),
+                    {ok, IView}
+            catch
+                _:Error ->
+                    clear_view_aggregation(View),
+                    {error, Error}
+            end
+    end.
+
+%% @private
+deregister_(Name) ->
     case ets:take(?VIEWS_TABLE, Name) of
         [] -> ok;
         [View] -> unsubscribe_(View)
-    end,
-    {reply, ok, State};
-handle_call({subscribe, Name}, _From,  State) ->
-    case view_by_name(Name) of
-        {ok, View} ->
-            case subscribe_(View) of
-                ok -> {reply, {ok, View#view{subscribed=true}}, State}
-            end;
-        unknown ->
-            {reply, {error, {unknown_view, Name}}, State}
-    end;
-handle_call({unsubscribe, Name}, _From, State) ->
-    case view_by_name(Name) of
-        {ok, View} ->
-            case unsubscribe_(View) of
-                ok ->
-                    {reply, {ok, View#view{subscribed=false}}, State}
-            end;
-        unknown ->
-            {reply, {error, {unknown_view, Name}}, State}
-    end;
-handle_call({register_measure, #measure{name=Name}=Measure}, _From, State) ->
-    case ets:lookup(?MEASURES_TABLE, Name) of
-        [OldMeasure] ->
-            {reply, {ok, OldMeasure}, State};
-        [] ->
-            ets:insert(?MEASURES_TABLE, Measure),
-            oc_stat_measure:regen_record(Name, []),
-            {reply, {ok, Measure}, State}
-    end;
-handle_call(_, _From, State) ->
-    {noreply, State}.
-
-handle_cast(_, State) ->
-    {noreply, State}.
-
-handle_info(_, State) ->
-    {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
-terminate(_, _) ->
-    [oc_stat_measure:delete_measure(M#measure.name) ||
-        M <- ets:tab2list(?MEASURES_TABLE)],
-    ok.
-
-%% private
-
-register_(#view{measure=Measure,
-                name=Name,
-                description=Description,
-                ctags=CTags,
-                tags=Keys,
-                aggregation=AggregationModule,
-                aggregation_options=AggregationOptions}) ->
-    NAggregationOptions = AggregationModule:init(Name, Keys, AggregationOptions),
-    try
-        NView = #view{measure=Measure,
-                      name=Name,
-                      subscribed=false,
-                      description=Description,
-                      ctags=CTags,
-                      tags=Keys,
-                      aggregation=AggregationModule,
-                      aggregation_options=NAggregationOptions},
-        ets:insert(?VIEWS_TABLE, NView),
-        {ok, NView}
-    catch
-        _:Error -> AggregationModule:clear_rows(Name, NAggregationOptions),
-                   {error, Error}
     end.
 
+%% @private
 subscribe_(#view{subscribed=true}) ->
     ok;
-subscribe_(#view{measure=Measure,
-                 name=Name,
-                 tags=Keys,
-                 aggregation=AggregationModule,
-                 aggregation_options=AggregationOptions}=View) ->
-    VS = #v_s{name=Name,
-              tags=Keys,
-              aggregation=AggregationModule,
-              aggregation_options=AggregationOptions},
-    case ets:lookup(?MEASURES_TABLE, Measure) of
-        [] ->
-            ets:insert(?MEASURES_TABLE, #measure{name=Measure,
-                                                 module=oc_stat_measure:module_name(Measure)}),
-            oc_stat_measure:regen_record(Measure, [VS]);
-        [#measure{module=Module}] ->
-            Subs = Module:subs(),
-            oc_stat_measure:regen_record(Measure, [VS | Subs])
-    end,
-    mark_view_as_subscribed_(View),
-    ok.
+subscribe_(#view{measure=Measure}=View) ->
+    VS =vs_from_view(View),
+    case oc_stat_measure:add_subscription_(Measure, VS) of
+        ok ->
+            {ok, mark_view_as_subscribed_(View)};
+        Error ->
+            Error
+    end;
+subscribe_(Name) ->
+    case view_by_name(Name) of
+        {ok, View} ->
+            subscribe_(View);
+        unknown ->
+            {error, {unknown_view, Name}}
+    end.
 
+%% @private
 unsubscribe_(#view{subscribed=false}) ->
     ok;
-unsubscribe_(#view{measure=Measure,
-                   name=Name,
+unsubscribe_(#view{measure=Measure}=View) ->
+    VS = vs_from_view(View),
+    oc_stat_measure:remove_subscription_(Measure, VS),
+    UView = mark_view_as_unsubscribed_(View),
+    clear_view_aggregation(View),
+    {ok, UView};
+unsubscribe_(Name) ->
+    case view_by_name(Name) of
+        {ok, View} ->
+            unsubscribe_(View);
+        unknown ->
+            {error, {unknown_view, Name}}
+    end.
+
+%% @private
+tag_values_(Tags, Keys) ->
+    lists:foldl(fun(Key, Acc) ->
+                        [maps:get(Key, Tags, undefined) | Acc]
+                end, [], Keys).
+
+%% @private
+'__init_backend__'() ->
+    ?VIEWS_TABLE = ets:new(?VIEWS_TABLE, [set, named_table, public, {keypos, 2}, {read_concurrency, true}]),
+    ok.
+
+%% =============================================================================
+%% private
+%% =============================================================================
+
+-spec vs_from_view(view()) -> v_s().
+vs_from_view(#view{name=Name,
                    tags=Keys,
                    aggregation=AggregationModule,
-                   aggregation_options=AggregationOptions}=View) ->
-    VS = #v_s{name=Name,
-              tags=Keys,
-              aggregation=AggregationModule,
-              aggregation_options=AggregationOptions},
-    case ets:lookup(?MEASURES_TABLE, Measure) of
-        [] ->
-            ok;
-        [#measure{module=Module}] ->
-            Subs = Module:subs(),
-            oc_stat_measure:regen_record(Measure, lists:delete(VS, Subs))
-    end,
-    mark_view_as_unsubscribed_(View),
-    #view{aggregation=AggregationModule,
-          aggregation_options=AggregationOptions} = View,
-    AggregationModule:clear_rows(Name, AggregationOptions),
-    ok.
+                   aggregation_options=AggregationOptions}) ->
+    #v_s{name=Name,
+         tags=Keys,
+         aggregation=AggregationModule,
+         aggregation_options=AggregationOptions}.
+
+init_view_aggregation(#view{name=Name,
+                            tags=Keys,
+                            aggregation=AggregationModule,
+                            aggregation_options=AggregationOptions} = View) ->
+    NAggregationOptions = AggregationModule:init(Name, Keys, AggregationOptions),
+    View#view{subscribed=false,
+              aggregation_options=NAggregationOptions}.
+
+clear_view_aggregation(#view{name=Name,
+                             aggregation=AggregationModule,
+                             aggregation_options=AggregationOptions}) ->
+    AggregationModule:clear_rows(Name, AggregationOptions).
 
 mark_view_as_subscribed_(View) ->
     swap(?VIEWS_TABLE, View, View#view{subscribed=true}).
 
 mark_view_as_unsubscribed_(View) ->
     swap(?VIEWS_TABLE, View, View#view{subscribed=false}).
-
-%% privates
 
 swap(Where, What, With) ->
     ets:select_replace(Where, [{What, [], [{const, With}]}]).
@@ -461,13 +372,3 @@ normalize_tags([First|Rest], {Map, List}) when is_map(First) ->
     normalize_tags(Rest, {maps:merge(Map, First), List});
 normalize_tags([First|Rest], {Map, List}) when is_atom(First) ->
     normalize_tags(Rest, {Map, [First | List]}).
-
-tag_values(Tags, Keys) ->
-    lists:foldl(fun(Key, Acc) ->
-                        [maps:get(Key, Tags, undefined) | Acc]
-                end, [], Keys).
-
-'__init_backend__'() ->
-    ?VIEWS_TABLE = ets:new(?VIEWS_TABLE, [set, named_table, public, {keypos, 2}, {read_concurrency, true}]),
-    ?MEASURES_TABLE = ets:new(?MEASURES_TABLE, [set, named_table, public, {keypos, 2}, {read_concurrency, true}]),
-    ok.

--- a/src/opencensus_sup.erl
+++ b/src/opencensus_sup.erl
@@ -46,12 +46,12 @@ init([]) ->
                  type => worker,
                  modules => [oc_stat_exporter]},
 
-    ViewServer = #{id => oc_stat_view,
-                   start => {oc_stat_view, start_link, []},
+    ViewServer = #{id => oc_stat,
+                   start => {oc_stat, start_link, []},
                    restart => permanent,
                    shutdown => 1000,
                    type => worker,
-                   modules => [oc_stat_view]},
+                   modules => [oc_stat]},
 
     TraceServer = #{id => oc_server,
                     start => {oc_server, start_link, []},

--- a/src/opencensus_sup.erl
+++ b/src/opencensus_sup.erl
@@ -32,10 +32,6 @@ start_link() ->
 init([]) ->
     ok = oc_sampler:init(application:get_env(opencensus, sampler, {oc_sampler_always, []})),
 
-    ok = oc_stat_view:'__init_backend__'(),
-
-    oc_stat_view:preload(oc_stat_config:views()),
-
     Reporter = #{id => oc_reporter,
                  start => {oc_reporter, start_link, []},
                  restart => permanent,

--- a/test/oc_stat_SUITE.erl
+++ b/test/oc_stat_SUITE.erl
@@ -95,7 +95,7 @@ operations(_Config) ->
              "number of videos processed processed over time",
              [#{ctag => value},
               type],
-             {oc_stat_aggregation_pid, self()}),
+             {oc_stat_aggregation_pid, pid_to_list(self())}),
 
     {ok, RView} = oc_stat_view:register(View),
     receive

--- a/test/oc_stat_aggregation_pid.erl
+++ b/test/oc_stat_aggregation_pid.erl
@@ -8,9 +8,10 @@
 
 -behavior(oc_stat_aggregation).
 
-init(_Name, _Keys, Pid) ->
+init(_Name, _Keys, Pid0) ->
+    Pid = list_to_pid(Pid0),
     Pid ! aggregation_init,
-    Pid.
+    Pid0.
 
 type() ->
     pid.
@@ -23,6 +24,7 @@ export(_Name, _Options) ->
     #{type=>type(),
       rows=>[]}.
 
-clear_rows(_Name, Pid) ->
+clear_rows(_Name, Pid0) ->
+    Pid = list_to_pid(Pid0),
     Pid ! aggregation_clear_rows,
     ok.

--- a/test/oc_stat_pt_user.erl
+++ b/test/oc_stat_pt_user.erl
@@ -1,0 +1,12 @@
+-module(oc_stat_pt_user).
+
+-export([record_non_existing/0,
+         record_ok/0]).
+
+-compile({parse_transform, oc_stat_measure}).
+
+record_non_existing() ->
+    oc_stat:record(#{}, "qwe", 1).
+
+record_ok() ->
+    oc_stat_measure:record(#{}, 'my.org/measures/video_size', 1024).


### PR DESCRIPTION
Generates a module for each measure with two functions 
- subs/0 - returns all subscriptions;
- record(tags, value) - records value via unrolled loop.

Also oc_stat_measure transform which replaces `oc_stat:record` calls with a direct measure module record calls.

Numbers (same views and measure from oc_stat_SUITE):

**SINGLE**
```erlang
 oc_stat:record(Tags, 'my.org/measures/video_count', 1)
```

```
OLD:

Running single counter benchmark:
  Pids: 1
  Iterations: 1000000
  Expected Value: 1000000
  Duration (sec): 0.602 (100.0%)
  Counter value: 1000000

Running single counter benchmark:
  Pids: 100
  Iterations: 1000000
  Expected Value: 116000000
  Duration (sec): 19.222 (100.0%)
  Counter value: 116000000


NEW:

Running single counter benchmark:
  Pids: 1
  Iterations: 1000000
  Expected Value: 1000000
  Duration (sec): 0.528 (100.0%)
  Counter value: 1000000

Running single counter benchmark:
  Pids: 100
  Iterations: 1000000
  Expected Value: 116000000
  Duration (sec): 16.749 (100.0%)
  Counter value: 116000000


NEW parse_transform:

Running single counter benchmark:
  Pids: 1
  Iterations: 1000000
  Expected Value: 1000000
  Duration (sec): 0.368 (100.0%)
  Counter value: 1000000

Running single counter benchmark:
  Pids: 100
  Iterations: 1000000
  Expected Value: 116000000
  Duration (sec): 12.056 (100.0%)
  Counter value: 116000000

```

**MULTIPLE**

```erlang

  
  oc_stat:record(Tags, 'my.org/measures/video_count', 1),
  oc_stat:record(Ctx, [{'my.org/measures/video_count', 1},
                       {'my.org/measures/video_size_sum', 1024}]),
  oc_stat:record(Tags, 'my.org/measures/video_size_sum', 4096),
  oc_stat:record(Ctx, [{'my.org/measures/video_count', 1},
                       {'my.org/measures/video_size_sum', 1024}]),
```

```
OLD:

Running multi counter benchmark:
  Pids: 1
  Iterations: 1000000
  Expected Value: 3000000
  Duration (sec): 6.907 (100.0%)
  Counter value: 3000000
Running multi counter benchmark:
  Pids: 10
  Iterations: 1000000
  Expected Value: 48000000
  Duration (sec): 30.5 (100.0%))
  Counter value: 48000000
Finished


NEW:

Running multi counter benchmark:
  Pids: 1
  Iterations: 1000000
  Expected Value: 3000000
  Duration (sec): 5.772 (100.0%)
  Counter value: 3000000
Running multi counter benchmark:
  Pids: 10
  Iterations: 1000000
  Expected Value: 48000000
  Duration (sec): 28.098 (100.0%)
  Counter value: 48000000
Finished


NEW parse_transform:

Running multi counter benchmark:
  Pids: 1
  Iterations: 1000000
  Expected Value: 3000000
  Duration (sec): 4.694 (100.0%)
  Counter value: 3000000
Running multi counter benchmark:
  Pids: 10
  Iterations: 1000000
  Expected Value: 48000000
  Duration (sec): 27.214 (100.0%)
  Counter value: 48000000
Finished

```

Single counter tests highlight improvements better, with multi counter most of the time spent inside aggregations. Parse transform effectively eliminates subscription overhead completely!