### PR TITLE
Start with units

### DIFF
--- a/src/oc_stat_measure.erl
+++ b/src/oc_stat_measure.erl
@@ -33,7 +33,8 @@
 
 %% user api
 -export([new/3,
-         exists/1]).
+         exists/1,
+         unit/1]).
 
 %% codegen
 -export([measure_module/1,
@@ -81,13 +82,19 @@ new(Name, Description, Unit) ->
 %% @doc
 %% Returns a measure with the `Name' or `false'..
 %% @end
--spec exists(name()) -> measure() | false.
+-spec exists(name() | measure()) -> measure() | false.
+exists(#measure{name=Name}) ->
+    exists(Name);
 exists(Name) ->
     case ets:lookup(?MEASURES_TABLE, Name) of
         [Measure] ->
             Measure;
         _ -> false
     end.
+
+-spec unit(measure()) -> unit().
+unit(#measure{unit=Unit}) ->
+    Unit.
 
 %% =============================================================================
 %% internal
@@ -109,10 +116,10 @@ insert_measure_(#measure{module=Module}=Measure) ->
     Measure.
 
 %% @private
-add_subscription_(Name, VS) ->
-    case exists(Name) of
+add_subscription_(Measure, VS) ->
+    case exists(Measure) of
         false ->
-            {error, {unknown_measure, Name}};
+            {error, {unknown_measure, Measure}};
         #measure{module=Module} ->
             Subs = Module:subs(),
             regen_record(Module, [VS | Subs]),

--- a/src/oc_stat_unit.erl
+++ b/src/oc_stat_unit.erl
@@ -1,0 +1,59 @@
+-module(oc_stat_unit).
+
+-export([is_comparable/2,
+         must_convert/1,
+         convert/3]).
+
+%% ===================================================================
+%% API
+%% ===================================================================
+
+is_comparable(VUnit, MUnit) ->
+    {CVUnit, _} = canonical(VUnit),
+    {CMUnit, _} = canonical(MUnit),
+
+    case CMUnit of
+        arbitrary ->
+            false;
+        CVUnit ->
+            true;
+        _ ->
+            false
+    end.
+
+must_convert(native_time_unit) ->
+    true;
+must_convert(_) ->
+    false.
+
+convert(Value, From, To) ->
+    case is_comparable(From, To) of
+        false -> {error, {not_comparable_units, From, To}};
+        true ->
+            {_, FMult} = canonical(From),
+            {_, TMult} = canonical(To),
+            Value * FMult / TMult
+    end.
+
+%% ===================================================================
+%% Private functions
+%% ===================================================================
+
+canonical(native_time_unit) ->
+    {native_time_unit, 1};
+canonical(nanosecond) ->
+    {native_time_unit, erlang:convert_time_unit(1, nanosecond, native)};
+canonical(microsecond) ->
+    {native_time_unit, erlang:convert_time_unit(1, microsecond, native)};
+canonical(millisecond) ->
+    {native_time_unit, erlang:convert_time_unit(1, millisecond, native)};
+canonical(second) ->
+    {native_time_unit, erlang:convert_time_unit(1, second, native)};
+canonical(minute) ->
+    {native_time_unit, 60 * erlang:convert_time_unit(1, second, native)};
+canonical(hour) ->
+    {native_time_unit, 3600 * erlang:convert_time_unit(1, second, native)};
+canonical(day) ->
+    {native_time_unit, 3600 * 24 * erlang:convert_time_unit(1, second, native)};
+canonical(_) ->
+    {arbitrary, arbitrary}.

--- a/test/oc_reporters_SUITE.erl
+++ b/test/oc_reporters_SUITE.erl
@@ -46,7 +46,6 @@ init_per_testcase(zipkin_reporter, Config) ->
     {ok, _} = application:ensure_all_started(opencensus),
     Config.
 
-
 end_per_testcase(_, _Config) ->
     ok = application:stop(opencensus),
     ok.

--- a/test/oc_stat_unit_SUITE.erl
+++ b/test/oc_stat_unit_SUITE.erl
@@ -1,0 +1,60 @@
+-module(oc_stat_unit_SUITE).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    [conversion,
+     errors].
+
+init_per_suite(Config) ->
+    application:load(opencensus),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_, Config) ->
+    {ok, _} = application:ensure_all_started(opencensus),
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok = application:stop(opencensus),
+    ok = application:stop(counters),
+    ok.
+
+conversion(_Config) ->
+    oc_stat_measure:new(http_request_duration, "Http request duration", native_time_unit),
+    oc_stat_view:subscribe(http_request_duration_seconds,
+                           http_request_duration, second, "desc", [], oc_stat_aggregation_sum),
+    oc_stat:record(#{}, http_request_duration, 1200000),
+    oc_stat:record(#{}, http_request_duration, 1200000000),
+
+    ?assertMatch([#{name := http_request_duration_seconds,
+                    description := "desc",
+                    tags := [],
+                    ctags := #{},
+                    data := #{rows := [#{tags := [],
+                                         value := #{count := 2,
+                                                    mean := 0.6006,
+                                                    sum := 1.2012}}],
+                              type := sum}}],
+                 oc_stat:export()).
+
+errors(_Config) ->
+    oc_stat_measure:new(http_request_duration, "Http request duration", native_time_unit),
+    ?assertMatch({error, {invalid_unit, "view must override measure unit",
+                          native_time_unit}},
+                 oc_stat_view:subscribe(http_request_duration_seconds,
+                                        http_request_duration, "desc", [], oc_stat_aggregation_sum)),
+
+    oc_stat_measure:new(http_requests, "Http requests count", "req"),
+    ?assertMatch({error, {not_comparable_units, "req", "ms"}},
+                 oc_stat_view:subscribe(http_requests_count,
+                                        http_requests, "ms", "desc", [], oc_stat_aggregation_count)).
+
+%% ===================================================================
+%% Private functions
+%% ===================================================================


### PR DESCRIPTION
I decided to focus on what's needed first. Time units conversion. 

Library authors are free to create their measures with `native_time_unit` and force views to override. Or use real time units and still allow overrides. If known time unit used, all recorded values must be in native time units.

Example from the tests:

```erlang
    oc_stat_measure:new(http_request_duration, "Http request duration", native_time_unit),
    oc_stat_view:subscribe(http_request_duration_seconds,
                           http_request_duration, second, "desc", [], oc_stat_aggregation_sum),
    oc_stat:record(#{}, http_request_duration, 1200000),
    oc_stat:record(#{}, http_request_duration, 1200000000),

    ?assertMatch([#{name := http_request_duration_seconds,
                    description := "desc",
                    tags := [],
                    ctags := #{},
                    data := #{rows := [#{tags := [],
                                         value := #{count := 2,
                                                    mean := 0.6006,
                                                    sum := 1.2012}}],
                              type := sum}}],
                 oc_stat:export())
```

Or as real world example Phoenix instrumentation measures straightforward(https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#module-callbacks-cycle):

```elixir
Opencensus.Stat.Measure.new(:phoenix_controller_call_duration, "descr", :native_time_unit)

def phoenix_controller_call(:stop, time_diff, %{conn: conn, compile: compile} = data) do
  tags = ...
  Opencensus.Stat.record(tags, :phoenix_controller_call_duration, time_diff)
end
```