### PR TITLE
initial work on sweeper process for cleaning up orphaned spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ The `oc_span_sweeper` process checks for active spans which started greater than
 * `failed_attribute_and_finish`: An attribute `finished_by_sweeper` with value `true` is added to the span data and then the span is finished.
 * Custom function: Any funtion with type spec `fun((opencensus:span()) -> ok)` can be used. Note that the span is not removed from the active spans table if this method is used and the function must do the removal if it deems it necessary.
 
+An example configuration in `sys.config` to run a check every 5 minutes, dropping active spans older than 5 minutes can be found in the example project `helloworld`, `examples/helloworld/config/sys.config`, the sweeper snippet looks like:
+
+``` erlang
+{sweep_timeout, 300000},
+{sweep_strategy, drop},
+{span_ttl, 300000}
+```
+
 ### <a name="Logging">Logging</a> ###
 
 OTP-21 includes a new logging framework. When a context is created with a span (for example `ocp:with_child_span/1` or `oc_trace:with_child_span/2`) opencensus will update the current process's logger metadata to include the `trace_id`, `span_id` and `trace_options` with the latest ids under the key `span_ctx`, `trace_options` will be `1` if the trace is enabled. To use these with the default formatter you can create a custom template that includes them if they exist like so:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Headers = [{oc_span_ctx_header:field_name(), EncodedSpanCtx}],
 
 Active spans have their data stored in an ETS table. When a span is finished it is removed from the active spans table and moved to a table handled by the reporter process. If a span isn't finished, either because of a mistake in the code creating and finishing spans, or the process with open spans crashes before being able to finish the spans, there would be a memory leak.
 
-The `oc_span_sweeper` process checks for active spans which started greater than a configurable (`span_ttl`) duration, with a default of 5 minutes. There are 4 strategies for handling a span that is older than the time to live (`sweep_strategy`):
+The `oc_span_sweeper` process checks for active spans which started greater than a configurable (`span_ttl`) duration, with a default of 5 minutes. There are 4 strategies for handling a span that is older than the time to live (`strategy`):
 
 * `drop`: Spans are removed from the active span table and a log message is written with the total number of spans being dropped in this sweep.
 * `finish`: Each span is finished as is.
@@ -96,10 +96,12 @@ The `oc_span_sweeper` process checks for active spans which started greater than
 An example configuration in `sys.config` to run a check every 5 minutes, dropping active spans older than 5 minutes can be found in the example project `helloworld`, `examples/helloworld/config/sys.config`, the sweeper snippet looks like:
 
 ``` erlang
-{sweep_timeout, 300000},
-{sweep_strategy, drop},
-{span_ttl, 300000}
+{sweeper, #{interval => 300000,
+            strategy => drop,
+            span_ttl => 300000}}
 ```
+
+To disable sweeping set `interval` to `infinity`.
 
 ### <a name="Logging">Logging</a> ###
 

--- a/examples/helloworld/config/sys.config
+++ b/examples/helloworld/config/sys.config
@@ -4,9 +4,9 @@
 
                {stat, [{exporters, [{oc_stat_exporter_stdout, []}]}]},
 
-               {sweep_timeout, 300000},
-               {sweep_strategy, drop},
-               {span_ttl, 300000}]},
+               {sweeper, #{interval => 300000,
+                           strategy => drop,
+                           span_ttl => 300000}}]},
 
  {kernel,
   [{logger,

--- a/examples/helloworld/config/sys.config
+++ b/examples/helloworld/config/sys.config
@@ -2,7 +2,11 @@
  {opencensus, [{sampler, {oc_sampler_always, []}},
                {reporter, {oc_reporter_stdout, []}},
 
-               {stat, [{exporters, [{oc_stat_exporter_stdout, []}]}]}]},
+               {stat, [{exporters, [{oc_stat_exporter_stdout, []}]}]},
+
+               {sweep_timeout, 300000},
+               {sweep_strategy, drop},
+               {span_ttl, 300000}]},
 
  {kernel,
   [{logger,

--- a/include/opencensus.hrl
+++ b/include/opencensus.hrl
@@ -43,45 +43,45 @@
 
 -record(span, {
           %% name of the span
-          name                                    :: unicode:unicode_binary() | '_',
+          name                                    :: unicode:unicode_binary(),
 
           %% 128 bit int trace id
-          trace_id                                :: opencensus:trace_id() | undefined | '_',
+          trace_id                                :: opencensus:trace_id() | undefined,
 
           %% 64 bit int span id
-          span_id                                 :: opencensus:span_id() | undefined | '_',
+          span_id                                 :: opencensus:span_id() | undefined,
           %% 64 bit int parent span
-          parent_span_id                          :: opencensus:span_id() | undefined | '_',
+          parent_span_id                          :: opencensus:span_id() | undefined,
 
           %% 8-bit integer, lowest bit is if it is sampled
-          trace_options = 1                       :: integer() | undefined | '_',
+          trace_options = 1                       :: integer() | undefined,
 
-          kind = ?SPAN_KIND_UNSPECIFIED           :: opencensus:span_kind() | '_',
+          kind = ?SPAN_KIND_UNSPECIFIED           :: opencensus:span_kind(),
 
-          start_time                              :: wts:timestamp() | {'$1', '_'},
-          end_time                                :: wts:timestamp() | undefined | '_',
+          start_time                              :: wts:timestamp(),
+          end_time                                :: wts:timestamp() | undefined,
 
-          attributes = #{}                        :: opencensus:attributes() | '_',
+          attributes = #{}                        :: opencensus:attributes(),
 
           %% optional stacktrace from where the span was started
-          stack_trace                             :: opencensus:stack_trace() | undefined | '_',
+          stack_trace                             :: opencensus:stack_trace() | undefined,
 
           %% links to spans in other traces
-          links = []                              :: opencensus:links() | '_',
+          links = []                              :: opencensus:links(),
 
-          time_events = []                        :: opencensus:time_events() | '_',
+          time_events = []                        :: opencensus:time_events(),
 
           %% An optional final status for this span.
-          status = undefined                      :: opencensus:status() | undefined | '_',
+          status = undefined                      :: opencensus:status() | undefined,
 
           %% A highly recommended but not required flag that identifies when a trace
           %% crosses a process boundary. True when the parent_span belongs to the
           %% same process as the current span.
-          same_process_as_parent_span = undefined :: boolean() | undefined | '_',
+          same_process_as_parent_span = undefined :: boolean() | undefined,
 
           %% An optional number of child spans that were generated while this span
           %% was active. If set, allows implementation to detect missing child spans.
-          child_span_count = undefined            :: integer() | undefined | '_'
+          child_span_count = undefined            :: integer() | undefined
          }).
 
 -record(link, {

--- a/include/opencensus.hrl
+++ b/include/opencensus.hrl
@@ -43,45 +43,45 @@
 
 -record(span, {
           %% name of the span
-          name                                    :: unicode:unicode_binary(),
+          name                                    :: unicode:unicode_binary() | '_',
 
           %% 128 bit int trace id
-          trace_id                                :: opencensus:trace_id() | undefined,
+          trace_id                                :: opencensus:trace_id() | undefined | '_',
 
           %% 64 bit int span id
-          span_id                                 :: opencensus:span_id() | undefined,
+          span_id                                 :: opencensus:span_id() | undefined | '_',
           %% 64 bit int parent span
-          parent_span_id                          :: opencensus:span_id() | undefined,
+          parent_span_id                          :: opencensus:span_id() | undefined | '_',
 
           %% 8-bit integer, lowest bit is if it is sampled
-          trace_options = 1                       :: integer() | undefined,
+          trace_options = 1                       :: integer() | undefined | '_',
 
-          kind = ?SPAN_KIND_UNSPECIFIED           :: opencensus:span_kind(),
+          kind = ?SPAN_KIND_UNSPECIFIED           :: opencensus:span_kind() | '_',
 
-          start_time                              :: wts:timestamp(),
-          end_time                                :: wts:timestamp() | undefined,
+          start_time                              :: wts:timestamp() | {'$1', '_'},
+          end_time                                :: wts:timestamp() | undefined | '_',
 
-          attributes = #{}                        :: opencensus:attributes(),
+          attributes = #{}                        :: opencensus:attributes() | '_',
 
           %% optional stacktrace from where the span was started
-          stack_trace                             :: opencensus:stack_trace() | undefined,
+          stack_trace                             :: opencensus:stack_trace() | undefined | '_',
 
           %% links to spans in other traces
-          links = []                              :: opencensus:links(),
+          links = []                              :: opencensus:links() | '_',
 
-          time_events = []                        :: opencensus:time_events(),
+          time_events = []                        :: opencensus:time_events() | '_',
 
           %% An optional final status for this span.
-          status = undefined                      :: opencensus:status() | undefined,
+          status = undefined                      :: opencensus:status() | undefined | '_',
 
           %% A highly recommended but not required flag that identifies when a trace
           %% crosses a process boundary. True when the parent_span belongs to the
           %% same process as the current span.
-          same_process_as_parent_span = undefined :: boolean() | undefined,
+          same_process_as_parent_span = undefined :: boolean() | undefined | '_',
 
           %% An optional number of child spans that were generated while this span
           %% was active. If set, allows implementation to detect missing child spans.
-          child_span_count = undefined            :: integer() | undefined
+          child_span_count = undefined            :: integer() | undefined | '_'
          }).
 
 -record(link, {

--- a/src/oc_span_sweeper.erl
+++ b/src/oc_span_sweeper.erl
@@ -1,0 +1,99 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2018, OpenCensus Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%%------------------------------------------------------------------------
+-module(oc_span_sweeper).
+
+-behaviour(gen_statem).
+
+-export([start_link/0]).
+
+-export([init/1,
+         callback_mode/0,
+         handle_event/4,
+         code_change/4,
+         terminate/3]).
+
+-include("opencensus.hrl").
+-include("oc_logger.hrl").
+
+-define(EXPIRED_MS(Time, Return), [{#span{start_time={'$1', '_'}, _='_'},
+                                    [{'<', '$1', Time}],
+                                    [Return]}]).
+
+-record(data, {sweep_timeout :: integer(),
+               strategy :: drop | finish | failed_attribute_and_finish | fun((opencensus:span()) -> ok),
+               ttl :: integer()}).
+
+start_link() ->
+    gen_statem:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    SweepTimeout = application:get_env(opencensus, sweep_timeout, timer:minutes(5)),
+    Strategy = application:get_env(opencensus, sweep_strategy, drop),
+    TTL = application:get_env(opencensus, span_ttl, timer:minutes(5)),
+    {ok, ready, #data{sweep_timeout=SweepTimeout,
+                      strategy=Strategy,
+                      ttl=erlang:convert_time_unit(TTL, millisecond, native)},
+     [hibernate, {state_timeout, SweepTimeout, sweep}]}.
+
+callback_mode() ->
+    handle_event_function.
+
+handle_event(state_timeout, sweep, _, #data{sweep_timeout=SweepTimeout,
+                                            strategy=drop,
+                                            ttl=TTL}) ->
+    TooOld = erlang:monotonic_time() - TTL,
+    case ets:select_delete(?SPAN_TAB, ?EXPIRED_MS(TooOld, true)) of
+        0 ->
+            ok;
+        NumDeleted ->
+            ?LOG_INFO("sweep old spans: ttl=~p num_dropped=~p", [TTL, NumDeleted])
+    end,
+    {keep_state_and_data, [hibernate, {state_timeout, SweepTimeout, sweep}]};
+handle_event(state_timeout, sweep, _, #data{sweep_timeout=SweepTimeout,
+                                            strategy=finish,
+                                            ttl=TTL}) ->
+    Expired = select_expired(TTL),
+    [finish_span(Span) || Span <- Expired],
+    {keep_state_and_data, [hibernate, {state_timeout, SweepTimeout, sweep}]};
+handle_event(state_timeout, sweep, _, #data{sweep_timeout=SweepTimeout,
+                                            strategy=failed_attribute_and_finish,
+                                            ttl=TTL}) ->
+    Expired = select_expired(TTL),
+    [finish_span(oc_span:put_attribute(<<"finished_by_sweeper">>, true, Span)) || Span <- Expired],
+    {keep_state_and_data, [hibernate, {state_timeout, SweepTimeout, sweep}]};
+handle_event(state_timeout, sweep, _, #data{sweep_timeout=SweepTimeout,
+                                            strategy=Fun,
+                                            ttl=TTL}) when is_function(Fun) ->
+    Expired = select_expired(TTL),
+    [Fun(Span) || Span <- Expired],
+    {keep_state_and_data, [hibernate, {state_timeout, SweepTimeout, sweep}]};
+handle_event(_, _, _, _Data) ->
+    keep_state_and_data.
+
+code_change(_, State, Data, _) ->
+    {ok, State, Data}.
+
+terminate(_Reason, _State, _Data) ->
+    ok.
+
+%%
+
+finish_span(S=#span{span_id=SpanId}) ->
+    oc_span:finish_span(S),
+    ets:delete(?SPAN_TAB, SpanId).
+
+select_expired(TTL) ->
+    TooOld = erlang:monotonic_time() - TTL,
+    ets:select(?SPAN_TAB, ?EXPIRED_MS(TooOld, '$_')).

--- a/src/oc_span_sweeper.erl
+++ b/src/oc_span_sweeper.erl
@@ -31,7 +31,7 @@
                                     [{'<', '$1', Time}],
                                     [Return]}]).
 
--record(data, {sweep_timeout :: integer(),
+-record(data, {sweep_timeout :: integer() | infinity,
                strategy :: drop | finish | failed_attribute_and_finish | fun((opencensus:span()) -> ok),
                ttl :: integer()}).
 

--- a/src/opencensus_sup.erl
+++ b/src/opencensus_sup.erl
@@ -60,6 +60,13 @@ init([]) ->
                     type => worker,
                     modules => [oc_server]},
 
+    Sweeper = #{id => oc_span_sweeper,
+                start => {oc_span_sweeper, start_link, []},
+                restart => permanent,
+                shutdown => 1000,
+                type => worker,
+                modules => [oc_span_sweeper]},
+
     {ok, {#{strategy => one_for_one,
             intensity => 1,
-            period => 5}, [Reporter, Exporter, ViewServer, TraceServer]}}.
+            period => 5}, [Reporter, Exporter, ViewServer, TraceServer, Sweeper]}}.

--- a/test/oc_std_encoder_SUITE.erl
+++ b/test/oc_std_encoder_SUITE.erl
@@ -21,7 +21,8 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    ok = application:stop(opencensus).
+    ok = application:stop(opencensus),
+    application:unload(opencensus).
 
 init_per_testcase(_, Config) ->
     Config.

--- a/test/oc_sweeper_SUITE.erl
+++ b/test/oc_sweeper_SUITE.erl
@@ -26,9 +26,9 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(Type, Config) ->
-    application:set_env(opencensus, sweep_timeout, 250),
-    application:set_env(opencensus, sweep_strategy, Type),
-    application:set_env(opencensus, span_ttl, 500),
+    application:set_env(opencensus, sweeper, #{interval => 250,
+                                               strategy => Type,
+                                               span_ttl => 500}),
 
     application:set_env(opencensus, send_interval_ms, 1),
     application:set_env(opencensus, reporter, {oc_reporter_pid, []}),

--- a/test/oc_sweeper_SUITE.erl
+++ b/test/oc_sweeper_SUITE.erl
@@ -1,0 +1,131 @@
+
+%%% ---------------------------------------------------------------------------
+%%% @doc
+%%% @end
+%%% ---------------------------------------------------------------------------
+-module(oc_sweeper_SUITE).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include("oc_test_utils.hrl").
+-include("opencensus.hrl").
+
+all() ->
+    [drop,
+     finish,
+     failed_attribute_and_finish].
+
+init_per_suite(Config) ->
+    ok = application:load(opencensus),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(Type, Config) ->
+    application:set_env(opencensus, sweep_timeout, 250),
+    application:set_env(opencensus, sweep_strategy, Type),
+    application:set_env(opencensus, span_ttl, 500),
+
+    application:set_env(opencensus, send_interval_ms, 1),
+    application:set_env(opencensus, reporter, {oc_reporter_pid, []}),
+    application:set_env(opencensus, pid_reporter, #{pid => self()}),
+    {ok, _} = application:ensure_all_started(opencensus),
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok = application:stop(opencensus),
+    ok.
+
+drop(_Config) ->
+    SpanName1 = <<"span-1">>,
+    SpanCtx = oc_trace:start_span(SpanName1, undefined),
+
+    ChildSpanName1 = <<"child-span-1">>,
+    ChildSpanCtx = oc_trace:start_span(ChildSpanName1, SpanCtx),
+
+    [ChildSpanData] = ets:lookup(?SPAN_TAB, ChildSpanCtx#span_ctx.span_id),
+    ?assertEqual(ChildSpanName1, ChildSpanData#span.name),
+    ?assertEqual(SpanCtx#span_ctx.span_id, ChildSpanData#span.parent_span_id),
+
+    oc_trace:finish_span(ChildSpanCtx),
+
+    %% wait until the sweeper sweeps away the parent span
+    ?UNTIL(ets:tab2list(?SPAN_TAB) =:= []),
+
+    oc_trace:finish_span(SpanCtx),
+
+    receive
+        {span, S=#span{name=Name}} when Name =:= ChildSpanName1 ->
+            %% Verify the end time and duration are set when the span was finished
+            ?assertMatch({ST, O} when is_integer(ST)
+                                      andalso is_integer(O), S#span.start_time),
+            ?assertMatch({ST, O} when is_integer(ST)
+                                      andalso is_integer(O), S#span.end_time)
+    end,
+
+    %% sleep long enough that the reporter would have run again for sure
+    timer:sleep(10),
+
+    %% should be no reported span for span-1
+    ?assertEqual(no_span, receive
+                              {span, #span{name=N}} when N =:= SpanName1 ->
+                                  got_span
+                          after
+                              0 ->
+                                  no_span
+                          end).
+
+finish(_Config) ->
+    SpanName1 = <<"span-1">>,
+    SpanCtx = oc_trace:start_span(SpanName1, undefined),
+
+    ChildSpanName1 = <<"child-span-1">>,
+    ChildSpanCtx = oc_trace:start_span(ChildSpanName1, SpanCtx),
+    oc_trace:finish_span(ChildSpanCtx),
+
+    %% wait until the sweeper sweeps away the parent span
+    ?UNTIL(ets:tab2list(?SPAN_TAB) =:= []),
+
+    lists:foreach(fun(Name) ->
+                          receive
+                              {span, S=#span{name=Name}} ->
+                                  %% Verify the end time and duration are set when the span was finished
+                                  ?assertMatch({ST, O} when is_integer(ST)
+                                                            andalso is_integer(O), S#span.start_time),
+                                  ?assertMatch({ST, O} when is_integer(ST)
+                                                            andalso is_integer(O), S#span.end_time)
+                          end
+                  end, [SpanName1, ChildSpanName1]).
+
+failed_attribute_and_finish(_Config) ->
+    SpanName1 = <<"span-1">>,
+    SpanCtx = oc_trace:start_span(SpanName1, undefined),
+
+    ChildSpanName1 = <<"child-span-1">>,
+    ChildSpanCtx = oc_trace:start_span(ChildSpanName1, SpanCtx),
+
+    [ChildSpanData] = ets:lookup(?SPAN_TAB, ChildSpanCtx#span_ctx.span_id),
+    ?assertEqual(ChildSpanName1, ChildSpanData#span.name),
+    ?assertEqual(SpanCtx#span_ctx.span_id, ChildSpanData#span.parent_span_id),
+
+    oc_trace:finish_span(ChildSpanCtx),
+
+    %% wait until the sweeper sweeps away the parent span
+    ?UNTIL(ets:tab2list(?SPAN_TAB) =:= []),
+
+    receive
+        {span, S=#span{name=Name,
+                       attributes=Attributes}} when Name =:= SpanName1 ->
+            %% should have attribute finished_by_sweeper
+            ?assertMatch(#{<<"finished_by_sweeper">> := true}, Attributes),
+
+            %% Verify the end time and duration are set when the span was finished
+            ?assertMatch({ST, O} when is_integer(ST)
+                                      andalso is_integer(O), S#span.start_time),
+            ?assertMatch({ST, O} when is_integer(ST)
+                                      andalso is_integer(O), S#span.end_time)
+    end.


### PR DESCRIPTION
This adds a few ways to deal with spans that are not finished after some TTL (5 minutes is the default right now).

Right now the drop option just logs, but a metric might be better. I think it is likely the way we'll want to deal with unfinished spans at work, so I'll probably add that as an option soon.