### PR TITLE
Typo in type exports and dialyzer fixes

### DIFF
--- a/src/oc_stat.erl
+++ b/src/oc_stat.erl
@@ -71,7 +71,7 @@ record(Ctx, Measures) ->
     record(Tags, Measures).
 
 %% @doc Exports view_data of all subscribed views
--spec export() -> oc_stat_view:view_data().
+-spec export() -> [oc_stat_view:view_data()].
 export() ->
     [oc_stat_view:export(View) || View <- oc_stat_view:all_subscribed_()].
 

--- a/src/oc_stat_aggregation.erl
+++ b/src/oc_stat_aggregation.erl
@@ -21,7 +21,7 @@
 
 -export([convert/3]).
 
--export_types(data/0).
+-export_type([data/0]).
 
 -type data_rows(AggregationValue) :: [#{tags := tv(),
                                         value := AggregationValue}].

--- a/src/oc_stat_aggregation_count.erl
+++ b/src/oc_stat_aggregation_count.erl
@@ -30,8 +30,6 @@
          export/2,
          clear_rows/2]).
 
--export_types([value/0]).
-
 init(_Name, _Keys, Options) ->
     Options.
 

--- a/src/oc_stat_exporter.erl
+++ b/src/oc_stat_exporter.erl
@@ -25,7 +25,7 @@
          code_change/3,
          terminate/2]).
 
--export_types([exporter/0]).
+-export_type([exporter/0]).
 
 -compile({no_auto_import, [register/2]}).
 

--- a/src/oc_stat_measure.erl
+++ b/src/oc_stat_measure.erl
@@ -51,10 +51,10 @@
 
 -export(['__init_backend__'/0]).
 
--export_types([name/0,
-               description/0,
-               unit/0,
-               measure/0]).
+-export_type([name/0,
+              description/0,
+              unit/0,
+              measure/0]).
 
 -record(measure, {name        :: name(),
                   module      :: module(),

--- a/src/oc_stat_view.erl
+++ b/src/oc_stat_view.erl
@@ -48,11 +48,10 @@
          tag_values_/2,
          all_subscribed_/0]).
 
--export_types([name/0,
-               description/0,
-               view/0,
-               view_data/0,
-               measure/0]).
+-export_type([name/0,
+              description/0,
+              view/0,
+              view_data/0]).
 
 -export(['__init_backend__'/0]).
 

--- a/src/oc_tags.erl
+++ b/src/oc_tags.erl
@@ -29,9 +29,9 @@
          verify_value/1,
          format_error/1]).
 
--export_types([key/0,
-               value/0,
-               tags/0]).
+-export_type([key/0,
+              value/0,
+              tags/0]).
 
 -include("opencensus.hrl").
 


### PR DESCRIPTION
It was `export_types` instead of proper `export_type`, also there were
some Dialyzer errors out there.

Strange that Dialyzer didn't catch that.