### PR TITLE
remove read/write concurrency settings from ets tables

### DIFF
--- a/src/oc_sampler_period_or_count.erl
+++ b/src/oc_sampler_period_or_count.erl
@@ -31,9 +31,7 @@
 %% public
 
 init(Opts) ->
-    _ = ets:new(?ETS_TABLE, [named_table, public,
-                             {read_concurrency, true},
-                             {write_concurrency, true}]),
+    _ = ets:new(?ETS_TABLE, [named_table, public]),
 
     Period0 = proplists:get_value(period, Opts, ?DEFAULT_PERIOD),
     %% TODO: check Period0 is a non-negative integer

--- a/src/oc_server.erl
+++ b/src/oc_server.erl
@@ -43,8 +43,7 @@ handle_cast(_, State) ->
 maybe_init_ets() ->
     case ets:info(?SPAN_TAB, name) of
         undefined ->
-            ets:new(?SPAN_TAB, [named_table, public, {write_concurrency, true},
-                                {read_concurrency, true}, {keypos, #span.span_id}]);
+            ets:new(?SPAN_TAB, [named_table, public, {write_concurrency, true}, {keypos, #span.span_id}]);
         _ ->
             ok
     end.

--- a/src/oc_stat_measure.erl
+++ b/src/oc_stat_measure.erl
@@ -148,7 +148,7 @@ terminate_() ->
 
 %% @private
 '__init_backend__'() ->
-    ?MEASURES_TABLE = ets:new(?MEASURES_TABLE, [set, named_table, public, {keypos, 2}, {read_concurrency, true}]),
+    ?MEASURES_TABLE = ets:new(?MEASURES_TABLE, [set, named_table, public, {keypos, 2}]),
     ok.
 
 %% =============================================================================

--- a/src/oc_stat_view.erl
+++ b/src/oc_stat_view.erl
@@ -369,7 +369,7 @@ tag_values_(Tags, Keys) ->
 
 %% @private
 '__init_backend__'() ->
-    ?VIEWS_TABLE = ets:new(?VIEWS_TABLE, [set, named_table, public, {keypos, 2}, {read_concurrency, true}]),
+    ?VIEWS_TABLE = ets:new(?VIEWS_TABLE, [set, named_table, public, {keypos, 2}]),
     ok.
 
 %% =============================================================================

--- a/src/opencensus_app.erl
+++ b/src/opencensus_app.erl
@@ -34,13 +34,11 @@ stop(_State) ->
 maybe_init_ets() ->
     case ets:info(?SPAN_TAB, name) of
         undefined ->
-            ets:new(?SPAN_TAB, [named_table, public, {write_concurrency, true},
-                                {read_concurrency, true}, {keypos, #span.span_id}]);
+            ets:new(?SPAN_TAB, [named_table, public, {write_concurrency, true}, {keypos, #span.span_id}]);
         _ ->
             ok
     end,
 
-     ets:new(oc_producer_registry, [bag, named_table, public, {write_concurrency, true},
-                                    {read_concurrency, true}]),
+     ets:new(oc_producer_registry, [bag, named_table, public]),
 
     oc_producer_registry:add_producer(oc_self_producer).

--- a/test/ocp_SUITE.erl
+++ b/test/ocp_SUITE.erl
@@ -27,8 +27,7 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(_, Config) ->
-    Tab = ets:new(reporter_tab, [public, {write_concurrency, true},
-                                 {read_concurrency, true}, {keypos, #span.span_id}]),
+    Tab = ets:new(reporter_tab, [public, {keypos, #span.span_id}]),
     application:set_env(opencensus, send_interval_ms, 1),
     application:set_env(opencensus, reporters, [{oc_tab_reporter, []}]),
     application:set_env(opencensus, tab_reporter, #{tid => Tab}),

--- a/test/opencensus_SUITE.erl
+++ b/test/opencensus_SUITE.erl
@@ -24,8 +24,7 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(_, Config) ->
-    Tab = ets:new(reporter_tab, [public, {write_concurrency, true},
-                                 {read_concurrency, true}, {keypos, #span.span_id}]),
+    Tab = ets:new(reporter_tab, [public, {keypos, #span.span_id}]),
     application:set_env(opencensus, send_interval_ms, 1),
     application:set_env(opencensus, reporters, [{oc_tab_reporter, []}]),
     application:set_env(opencensus, tab_reporter, #{tid => Tab}),


### PR DESCRIPTION
I don't think any of these are obviously going to improve performance and more likely hurt performance. Unless someone can say a certain case definitely involves the sort of read/write patterns that benefit from these options I think we need to remove them until someone does benchmarks.