### PR TITLE
LOG_INFO macro usage fix on earlier OTPs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,127 +1,59 @@
-defaults: &defaults
-  shell: /bin/sh
-  working_directory: /home/circleci/census
-  docker:
-    - image: erlang:21.2-alpine
-      cmd: ["/bin/sh"]
+version: 2.1
 
-version: 2
+orbs:
+  rebar3: tsloughter/rebar3@0.6.3
+  codecov: codecov/codecov@1.0.4
+
 jobs:
-  build:
-    <<: *defaults
+  build_and_test:
+    parameters:
+      tag:
+        description: The Erlang/OTP docker image tag to use
+        type: string
+      codecov_flag:
+        description: String the coverage reports are grouped by
+        type: string
+    executor:
+      name: rebar3/erlang
+      tag: <<parameters.tag>>
     steps:
       - checkout
+      - rebar3/with_deps_cache:
+          cache_key_postfix: -<<parameters.tag>>
+          steps:
+            - rebar3/compile
+            - rebar3/dialyzer
+            - run: rebar3 as test xref
+            - rebar3/ct
 
-      - restore_cache:
-          keys:
-            - census-{{ checksum "rebar.lock" }}
-            - census-hex-packages
+            - store_test_results:
+                path: ~/project/_build/test/logs/
+            - store_artifacts:
+                path: ~/project/_build/test/logs
+                destination: common_test
 
-      - run:
-          command: rebar3 compile
-
-      - store_artifacts:
-          path: /home/circleci/census/rebar3.crashdump
-          destination: rebar3_crashdump.txt
-          when: on_fail
-
-      - save-cache:
-          key: census-{{ checksum "rebar.lock" }}
-          paths:
-            - /home/circleci/census/_build/default/lib
-            - /home/circleci/census/_build/default/plugins
-
-      - save-cache:
-          key: census-hex-packages
-          paths:
-            - /root/.cache/rebar3/hex/default/packages
-
-  dialyzer:
-    <<: *defaults
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - erlang-plt-21.2
-
-      - restore_cache:
-          keys:
-            - census-{{ checksum "rebar.lock" }}
-            - census-hex-packages
-
-      - run:
-          command: rebar3 dialyzer
-
-      - save-cache:
-          key: erlang-plt-21.2
-          paths:
-            - /root/.cache/rebar3/rebar3_21.2_plt
-  xref:
-    <<: *defaults
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - census-{{ checksum "rebar.lock" }}
-            - census-hex-packages
-
-      - run:
-          command: rebar3 xref
-
-  lint:
-    <<: *defaults
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - census-{{ checksum "rebar.lock" }}
-            - census-hex-packages
-
-      - run:
-          command: rebar3 lint
-
-  tests:
-    <<: *defaults
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - census-{{ checksum "rebar.lock" }}
-            - census-hex-packages
-
-      - run:
-          command: |
-            set -eux
-            rebar3 do ct, cover
-            rebar3 covertool generate
-            apk add --update python python-dev py-pip
-            pip install codecov && codecov -f _build/test/covertool/opencensus.covertool.xml
-
-      - store_test_results:
-          path: /home/circleci/census/_build/test/logs/
-
-      - store_artifacts:
-          path: /home/circleci/census/_build/test/logs
-          destination: common_test
+            - rebar3/cover
+            - run: rebar3 as test covertool generate
+            - codecov/upload:
+                file: _build/test/covertool/rebar3_hex.covertool.xml
+                flags: <<parameters.codecov_flag>>
 
 workflows:
-  version: 2
-  build_and_test:
+  run_all:
     jobs:
-      - build
-      - dialyzer:
-          requires:
-            - build
-      - xref:
-          requires:
-            - build
-      - lint:
-          requires:
-            - build
-      - tests:
-          requires:
-            - build
+      - build_and_test:
+          name: "otp-21"
+          tag: "21.2"
+          codecov_flag: "otp21"
+      - build_and_test:
+          name: "otp-20"
+          tag: "20"
+          codecov_flag: "otp20"
+      - build_and_test:
+          name: "otp-19"
+          tag: "19"
+          codecov_flag: "otp19"
+      - build_and_test:
+          name: "otp-18"
+          tag: "18"
+          codecov_flag: "otp18"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             - rebar3/cover
             - run: rebar3 as test covertool generate
             - codecov/upload:
-                file: _build/test/covertool/rebar3_hex.covertool.xml
+                file: _build/test/covertool/opencensus.covertool.xml
                 flags: <<parameters.codecov_flag>>
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,11 +49,3 @@ workflows:
           name: "otp-20"
           tag: "20"
           codecov_flag: "otp20"
-      - build_and_test:
-          name: "otp-19"
-          tag: "19"
-          codecov_flag: "otp19"
-      - build_and_test:
-          name: "otp-18"
-          tag: "18"
-          codecov_flag: "otp18"

--- a/src/oc_propagation_http_b3.erl
+++ b/src/oc_propagation_http_b3.erl
@@ -38,8 +38,9 @@ to_headers(#span_ctx{trace_id=TraceId,
                      span_id=SpanId,
                      trace_options=TraceOptions}) ->
     Options = case TraceOptions band 1 of 1 -> "1"; _ -> "0" end,
-    EncodedTraceId = io_lib:format("~32.16.0b", [TraceId]),
-    EncodedSpanId = io_lib:format("~16.16.0b", [SpanId]),
+    %% iolist_to_binary only needed for versions before otp-21
+    EncodedTraceId = iolist_to_binary(io_lib:format("~32.16.0b", [TraceId])),
+    EncodedSpanId = iolist_to_binary(io_lib:format("~16.16.0b", [SpanId])),
     [{?B3_TRACE_ID, EncodedTraceId},
      {?B3_SPAN_ID, EncodedSpanId},
      {?B3_SAMPLED, Options}];

--- a/src/oc_propagation_http_b3.erl
+++ b/src/oc_propagation_http_b3.erl
@@ -85,7 +85,7 @@ trace_id(Headers) ->
 span_id(Headers) ->
     case lookup(?B3_SPAN_ID, Headers) of
         SpanId when is_list(SpanId) orelse is_binary(SpanId) ->
-            case string:length(SpanId) =:= 32 orelse string:length(SpanId) =:= 16 of
+            case string:length(SpanId) =:= 16 of
                 true ->
                     SpanId;
                 _ ->

--- a/src/oc_tracestate.erl
+++ b/src/oc_tracestate.erl
@@ -50,7 +50,7 @@ new(undefined, Entries) ->
         true ->
             #tracestate{entries=Entries};
         {false, Error} ->
-            ?LOG_INFO(format_error(Error)),
+            ?LOG_INFO(format_error(Error), []),
             undefined
     end;
 new(#tracestate{entries=ParentEntries}, Entries) ->
@@ -58,13 +58,13 @@ new(#tracestate{entries=ParentEntries}, Entries) ->
         true ->
             case add(#tracestate{entries=ParentEntries}, Entries) of
                 {error, Reason} ->
-                    ?LOG_INFO(format_error(Reason)),
+                    ?LOG_INFO(format_error(Reason), []),
                     undefined;
                 Tracestate ->
                     Tracestate
             end;
         {false, Error} ->
-            ?LOG_INFO(format_error(Error)),
+            ?LOG_INFO(format_error(Error), []),
             undefined
     end.
 


### PR DESCRIPTION
Also updates the circleci config to run against multiple OTP versions to catch stuff like this.