### PR TITLE
fix: Hackney leaks {ssl_closed, _} back to oc_reporter

### DIFF
--- a/src/oc_reporter.erl
+++ b/src/oc_reporter.erl
@@ -108,7 +108,9 @@ handle_info(report_spans, State=#state{reporters=Reporters,
     erlang:cancel_timer(Ref),
     Ref1 = erlang:send_after(SendInterval, self(), report_spans),
     send_spans(Reporters),
-    {noreply, State#state{timer_ref=Ref1}}.
+    {noreply, State#state{timer_ref=Ref1}};
+handle_info({ssl_closed, _}, State) ->
+    {noreply, State}.
 
 code_change(_, State, _) ->
     {ok, State}.


### PR DESCRIPTION
Tracked here: https://github.com/benoitc/hackney/issues/464
this became apparent when using `oc_google_reporter` which uses `Hackney`