### PR TITLE
Fixed module initialization order

### DIFF
--- a/src/opencensus_sup.erl
+++ b/src/opencensus_sup.erl
@@ -39,19 +39,19 @@ init([]) ->
                  type => worker,
                  modules => [oc_reporter]},
 
-    Exporter = #{id => oc_stat_exporter,
-                 start => {oc_stat_exporter, start_link, []},
-                 restart => permanent,
-                 shutdown => 1000,
-                 type => worker,
-                 modules => [oc_stat_exporter]},
-
     ViewServer = #{id => oc_stat,
                    start => {oc_stat, start_link, []},
                    restart => permanent,
                    shutdown => 1000,
                    type => worker,
                    modules => [oc_stat]},
+
+    Exporter = #{id => oc_stat_exporter,
+                 start => {oc_stat_exporter, start_link, []},
+                 restart => permanent,
+                 shutdown => 1000,
+                 type => worker,
+                 modules => [oc_stat_exporter]},
 
     TraceServer = #{id => oc_server,
                     start => {oc_server, start_link, []},
@@ -69,4 +69,4 @@ init([]) ->
 
     {ok, {#{strategy => one_for_one,
             intensity => 1,
-            period => 5}, [Reporter, Exporter, ViewServer, TraceServer, Sweeper]}}.
+            period => 5}, [Reporter, ViewServer, Exporter, TraceServer, Sweeper]}}.


### PR DESCRIPTION
Hello,
I was playing around with this library and encountered race condition after setting `export_interval` to `1`. I know that in general this is not reasonable value, but useful for testing / local development.

Please see stacktrace below

```
[error] Process #PID<0.209.0> raised an exception
** (ArgumentError) argument error
    (stdlib) :ets.match_object(:oc_stat_view, {:view, :_, :_, :_, true, :_, :_, :_, :_, :_})
    (opencensus) /home/mszczygiel/workspace/opencensus_elixir/deps/opencensus/src/oc_stat_view.erl:277: :oc_stat_view.all_subscribed_/0
    (opencensus) /home/mszczygiel/workspace/opencensus_elixir/deps/opencensus/src/oc_stat.erl:76: :oc_stat.export/0
    (opencensus) /home/mszczygiel/workspace/opencensus_elixir/deps/opencensus/src/oc_stat_exporter.erl:102: :oc_stat_exporter.export/1
```

This is caused by ETS `oc_stat_view` table being created after `export` is called.